### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+Before you report an issue, make sure these boxes are checked.
+
+- [ ] Make sure you're not reporting something that was just fixed.
+- [ ] Make sure you're not using an old version of Psi.
+- [ ] Make sure you're using Java 8.


### PR DESCRIPTION
This should stop some of the java7-using reporters.