### PR TITLE
Prevent possible overflows with tricky stat manipulation

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellMetadata.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellMetadata.java
@@ -38,9 +38,19 @@ public final class SpellMetadata {
 	/**
 	 * Adds a stat to the metadata, incrementing over the previous value.
 	 */
-	public void addStat(EnumSpellStat stat, int val) {
+	public void addStat(EnumSpellStat stat, int val) throws SpellCompilationException {
 		int curr = stats.get(stat);
-		setStat(stat, val + curr);
+		setStat(stat, safeSum(val, curr));
+	}
+
+	/**
+	 * Adds two numbers together, and throws a {@link SpellCompilationException} if they overflow MAX_INT.
+     */
+	private int safeSum(int a, int b) throws SpellCompilationException {
+		long r = ((long) a) + b;
+		if (r >>> 32 != 0)
+			throw new SpellCompilationException(SpellCompilationException.STAT_OVERFLOW);
+		return (int) r;
 	}
 
 	/**

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureBlock.java
@@ -52,7 +52,7 @@ public class PieceTrickConjureBlock extends PieceTrick {
 		addStats(meta);
 	}
 
-	public void addStats(SpellMetadata meta) {
+	public void addStats(SpellMetadata meta) throws SpellCompilationException {
 		meta.addStat(EnumSpellStat.POTENCY, 15);
 		meta.addStat(EnumSpellStat.COST, 20);
 	}

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureLight.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickConjureLight.java
@@ -13,6 +13,7 @@ package vazkii.psi.common.spell.trick.block;
 import net.minecraft.block.state.IBlockState;
 import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
+import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.common.block.BlockConjured;
 
@@ -23,7 +24,7 @@ public class PieceTrickConjureLight extends PieceTrickConjureBlock {
 	}
 
 	@Override
-	public void addStats(SpellMetadata meta) {
+	public void addStats(SpellMetadata meta) throws SpellCompilationException {
 		meta.addStat(EnumSpellStat.POTENCY, 50);
 		meta.addStat(EnumSpellStat.COST, 200);
 	}


### PR DESCRIPTION
This will preemptively bandaid all future spells that could possibly
overflow the counter via tricky use of constants (requiring at least 3
projection to do so).