### PR TITLE
Potential fix for issue #174

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
@@ -47,7 +47,7 @@ public class PieceOperatorEntityMotion extends PieceOperator {
 			EntityPlayer player = (EntityPlayer) e;
 			PlayerData data = PlayerDataHandler.get(player);
 			if(!data.eidosChangelog.isEmpty()) {
-				Vector3 last = data.eidosChangelog.get(data.eidosChangelog.size() - 1);
+				Vector3 last = data.eidosChangelog.get(data.eidosChangelog.size() - 2);
 				Vector3 vec = Vector3.fromEntity(e).sub(last);
 				if(vec.mag() < 10)
 					return vec;


### PR DESCRIPTION
Changed the used eidos entry to the one before the last, as the last is often the caster's current position and thus the result will mostly be a 0,0,0 vector.