### PR TITLE
Made grenade correctly track its lifetime. Fixes #219

### DIFF
--- a/src/main/java/vazkii/psi/common/entity/EntitySpellGrenade.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellGrenade.java
@@ -42,7 +42,7 @@ public class EntitySpellGrenade extends EntitySpellProjectile {
 	public void onUpdate() {
 		super.onUpdate();
 
-		if(timeAlive > 60 && !isDead && explodes())
+		if(ticksExisted > 60 && !isDead && explodes())
 			doExplosion();
 	}
 


### PR DESCRIPTION
The timeAlive field was never getting updated and was always 0. The ticksExisted field already exists and does the same job, so switched to that.