### PR TITLE
Fix Selector Nearby Smeltables

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/selector/entity/PieceSelectorNearbySmeltables.java
+++ b/src/main/java/vazkii/psi/common/spell/selector/entity/PieceSelectorNearbySmeltables.java
@@ -35,7 +35,7 @@ public class PieceSelectorNearbySmeltables extends PieceSelectorNearby {
 			ItemStack stack = eitem.getEntityItem();
 			ItemStack result = FurnaceRecipes.instance().getSmeltingResult(stack);
 		
-			return result != null;
+			return !result.isEmpty();
 		}
 		
 		return false;


### PR DESCRIPTION
Makes Nearby Smeltables actually select only smeltables.