### PR TITLE
Logic error using negative numbers in Max operator

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/operator/number/PieceOperatorMax.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/number/PieceOperatorMax.java
@@ -40,7 +40,7 @@ public class PieceOperatorMax extends PieceOperator {
 		Double d2 = this.<Double>getParamValue(context, num2);
 		Double d3 = this.<Double>getParamValue(context, num3);
 		if(d3 == null)
-			d3 = Double.MIN_VALUE;
+			d3 = Double.NEGATIVE_INFINITY;
 
 		return Math.max(d1, Math.max(d2, d3));
 	}


### PR DESCRIPTION
d3 defaults to Double.MIN_VALUE, which is the smallest POSITIVE number a double can hold. This means if d1 or d2 are a negative number, it will always return Double.MIN_VALUE instead of ignoring d3 like you'd expect. Using Double.NEGATIVE_INFINITY instead will resolve this.