### PR TITLE
Make PlayerData tick handling concurrency safe

### DIFF
--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -141,21 +141,20 @@ public class PlayerDataHandler {
 			if(event.phase == Phase.END) {
 				PlayerDataHandler.cleanup();
 
-				List<SpellContext> remove = new ArrayList();
-				for(SpellContext context : delayedContexts) {
+                Iterator<SpellContext> delayed = delayedContexts.iterator();
+                ArrayList<SpellContext> toExecute = new ArrayList();
+                
+                while(delayed.hasNext()) {
+                    SpellContext context = delayed.next();
 					context.delay--;
-
 					if(context.delay <= 0) {
-						context.delay = 0; // Just in case it goes under 0
-						context.cspell.safeExecute(context);
+                        context.delay = 0;
+                        toExecute.add(context);
+                        delayed.remove();
+                    }
+                }
 
-						if(context.delay == 0)
-							remove.add(context);
-					}
-				}
-
-				if(!remove.isEmpty())
-					delayedContexts.removeAll(remove);
+                toExecute.forEach(context -> context.cspell.safeExecute(context));
 			}
 		}
 


### PR DESCRIPTION
The tick handler calls cspell.safeExecute, which eventually adds the
context back onto a list that is being looped over at that moment,
causing a ConcurrentModificationException.

Use an iterator and move the safeExecute call out of the loop to prevent
this.

Fixes #363 (hopefully!)