### PR TITLE
Conjured Light Bounding Box Fix

### DIFF
--- a/src/main/java/vazkii/psi/common/block/BlockConjured.java
+++ b/src/main/java/vazkii/psi/common/block/BlockConjured.java
@@ -132,21 +132,6 @@ public class BlockConjured extends BlockModContainer implements IPsiBlock {
 	}
 
 	@Override
-	public AxisAlignedBB getSelectedBoundingBox(IBlockState state, World world, BlockPos pos) {
-		boolean solid = state.getValue(SOLID);
-		float f = solid ? 0F : 0.25F;
-
-		double minX = f;
-		double minY = f;
-		double minZ = f;
-		double maxX = 1F - f;
-		double maxY = 1F - f;
-		double maxZ = 1F - f;
-
-		return new AxisAlignedBB(pos.getX() + minX, pos.getY() + minY, pos.getZ() + minZ, pos.getX() + maxX, pos.getY() + maxY, pos.getZ() + maxZ);
-	}
-	
-	@Override
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess world, BlockPos pos) {
 		boolean solid = state.getValue(SOLID);
 		float f = solid ? 0F : 0.25F;

--- a/src/main/java/vazkii/psi/common/block/BlockConjured.java
+++ b/src/main/java/vazkii/psi/common/block/BlockConjured.java
@@ -145,6 +145,21 @@ public class BlockConjured extends BlockModContainer implements IPsiBlock {
 
 		return new AxisAlignedBB(pos.getX() + minX, pos.getY() + minY, pos.getZ() + minZ, pos.getX() + maxX, pos.getY() + maxY, pos.getZ() + maxZ);
 	}
+	
+	@Override
+	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess world, BlockPos pos) {
+		boolean solid = state.getValue(SOLID);
+		float f = solid ? 0F : 0.25F;
+
+		double minX = f;
+		double minY = f;
+		double minZ = f;
+		double maxX = 1F - f;
+		double maxY = 1F - f;
+		double maxZ = 1F - f;
+
+		return new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
+	}
 
 	@Override
 	public TileEntity createTileEntity(World world, IBlockState state) {


### PR DESCRIPTION
This fixes #91 and its duplicate #285. It turned out to be really simple to implement thanks to @williewillus's pointer to `Block.getBoundingBox` (in #91).
~There's some duplication now, which I unfortunately couldn't come up with a way around, but I suppose it's not bad.~