### PR TITLE
Added a null check to projectile collision callback. Fixes #376

### DIFF
--- a/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
@@ -186,7 +186,9 @@ public class EntitySpellProjectile extends EntityThrowable {
 		if(pos.entityHit != null && pos.entityHit instanceof EntityLivingBase) {
 			EntityLivingBase e = (EntityLivingBase) pos.entityHit; // apparently RayTraceResult is mutable \:D/
 			cast((SpellContext context) -> {
-				context.attackedEntity = e;
+				if (context != null) {
+					context.attackedEntity = e;
+				}
 			});
 		} else cast();
 	}


### PR DESCRIPTION
Spells do not have SpellContexts (in at least some cases) for clients other than the spell owner. This can cause a NPE in the projectile's collision handling code, which blindly assumes the context is there to set a value on it. This change simply adds a null check to the relevant callback.