### PR TITLE
Use forge reach attribute instead of hardcoded reach

### DIFF
--- a/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalTool.java
+++ b/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalTool.java
@@ -55,7 +55,7 @@ public class ItemPsimetalTool extends ItemModTool implements IPsimetalTool {
 			ItemStack bullet = getBulletInSocket(itemstack, getSelectedSlot(itemstack));
 			ItemCAD.cast(player.getEntityWorld(), player, data, bullet, playerCad, 5, 10, 0.05F, (SpellContext context) -> {
 				context.tool = itemstack;
-				context.positionBroken = raytraceFromEntity(player.getEntityWorld(), player, false, 5);
+				context.positionBroken = raytraceFromEntity(player.getEntityWorld(), player, false, player.getAttributeMap().getAttributeInstance(EntityPlayer.REACH_DISTANCE).getAttributeValue());
 			});
 		}
 


### PR DESCRIPTION
Instead of checking for a hardcoded value for reach use forge's reach attribute thus fixing #450 