### PR TITLE
Adds decorative block back to creative tab, fixes lang typo, fixes player motion displaying incorrect value

### DIFF
--- a/src/main/java/vazkii/psi/common/block/BlockPsiDecorative.java
+++ b/src/main/java/vazkii/psi/common/block/BlockPsiDecorative.java
@@ -17,6 +17,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import vazkii.arl.block.BlockMetaVariants;
 import vazkii.psi.common.block.base.IPsiBlock;
+import vazkii.psi.common.core.PsiCreativeTab;
 import vazkii.psi.common.lib.LibBlockNames;
 
 public class BlockPsiDecorative extends BlockMetaVariants implements IPsiBlock {
@@ -26,6 +27,7 @@ public class BlockPsiDecorative extends BlockMetaVariants implements IPsiBlock {
 		setHardness(5.0F);
 		setResistance(10.0F);
 		setSoundType(SoundType.METAL);
+		setCreativeTab(PsiCreativeTab.INSTANCE);
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
@@ -48,8 +48,8 @@ public class PieceOperatorEntityMotion extends PieceOperator {
 			PlayerData data = PlayerDataHandler.get(player);
 			if(data.eidosChangelog.size() >= 2) {
 				Vector3 last = data.eidosChangelog.get(data.eidosChangelog.size() - 2);
-				Vector3 vec = Vector3.fromEntity(e).sub(last);
-				if(vec.mag() < 10)
+				Vector3 vec = Vector3.fromEntity(e).sub(last).multiply(1.0 / PieceTrickAddMotion.MULTIPLIER);
+				if(vec.mag() < 33.4)
 					return vec;
 			}
 		}

--- a/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
+++ b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java
@@ -49,7 +49,7 @@ public class PieceOperatorEntityMotion extends PieceOperator {
 			if(data.eidosChangelog.size() >= 2) {
 				Vector3 last = data.eidosChangelog.get(data.eidosChangelog.size() - 2);
 				Vector3 vec = Vector3.fromEntity(e).sub(last).multiply(1.0 / PieceTrickAddMotion.MULTIPLIER);
-				if(vec.mag() < 33.4)
+				if(vec.mag() < 10)
 					return vec;
 			}
 		}

--- a/src/main/resources/assets/psi/lang/en_US.lang
+++ b/src/main/resources/assets/psi/lang/en_US.lang
@@ -90,6 +90,8 @@ tile.psi:psimetal_plate_cyan_light.name=Bright Psimetal Flow Plate
 tile.psi:ebony_psimetal_block.name=Ebony Psimetal Block
 tile.psi:ivory_psimetal_block.name=Ivory Psimetal Block
 tile.psi:conjured.name=Conjured Block
+tile.psi:psimetal_plate_white.name=Bright Psimetal Plate
+tile.psi:psimetal_plate_white_light.name=Bright Psimetal Flow Plate
 
 # ITEM NAMES
 item.psi:psidust.name=Psidust


### PR DESCRIPTION
Adds all the decorative blocks back to creative tabs
Fixes the lang typo
Fixes entity motion displaying wrong magnitude for the player


~~Only thing I'm unsure about is https://github.com/Kamefrede/Psi/blob/18130ac16aefd1f08ea6dba576d461a57e75a50b/src/main/java/vazkii/psi/common/spell/operator/entity/PieceOperatorEntityMotion.java#L52 , if it should remain 10 or be changed to 33,4 ( 10 multiplied by the add motion multiplier)~~

