### PR TITLE
Port gradle fixes, fix JEI trick crafting not being shown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,52 +89,57 @@ task deobfJar(type: Jar) {
     from(sourceSets.main.output)
     archiveName = "${baseName}-${version}-deobf.${extension}"
 }
+task srcJar(type: Jar) {
+    from(sourceSets.main.java)
+    classifier = 'sources'
+    archiveName = "${baseName}-${version}-sources.${extension}"
+}
+task apiJar(type: Jar) {
+    // Remove sources from the api jar when MinecraftForge/ForgeGradle#369 is fixed
+    from(sourceSets.main.allJava)
+    from(sourceSets.main.output)
+    include 'vazkii/psi/api/**'
+
+    classifier = 'api'
+    archiveName = "${baseName}-${version}-api.${extension}"
+}
 
 artifacts {
-    archives deobfJar
+    archives srcJar, apiJar
 }
 /**
  * Increments the buildnumber in your config file, and saves it
  */
 task incrementBuildNumber {
-    config.build_number = (config.build_number.toString().toInteger()) + 1
-    configFile.withWriter {
-        config.toProperties().store(it, "")
+    doLast {
+        config.build_number = (config.build_number.toString().toInteger()) + 1
+        configFile.withWriter {
+            config.toProperties().store(it, "")
+        }
+
+        file('web/versions.ini').append("\n${version}=${minecraft.version}")
+        file("${config.dir_repo}/version/${minecraft.version}.txt").write("${version}")
     }
-
-    file('web/versions.ini').append("\n${version}=${minecraft.version}")
-    file("${config.dir_repo}/version/${minecraft.version}.txt").write("${version}")
 }
 
-// I have no idea what I'm doing
-task wtfGradle2(type: Copy) {
-    from(jar.destinationDir)
-    into file("${config.dir_output}/wtf")
-}
+import java.util.regex.Pattern
 
-// Seriously, I'm desperate to make this work
-task wtfGradle1(type: Delete) {
-    dependsOn "wtfGradle2"
-    delete "${config.dir_output}/wtf/${deobfJar.archiveName}"
-}
-
-task output(type: Copy) {
-    dependsOn "wtfGradle1"
-    from(jar.destinationDir)
-    into file(config.dir_output)
-}
-
-task outputDeobf(type: Copy) {
-    dependsOn "output"
-    from(config.dir_output) {
-        include deobfJar.archiveName
+task sortArtifacts(type: Copy) {
+    from jar.destinationDir
+    into config.dir_output
+    //Put each jar with a classifier in a subfolder with the classifier as its name
+    eachFile {
+        //This matcher is used to get the classifier of the jar
+        def matcher = Pattern.compile(Pattern.quote("$config.mod_name-$version") + "-(?<classifier>\\w+).jar").matcher(it.name)
+        //Only change the destination for full matches, i.e jars with classifiers
+        if (matcher.matches())
+        {
+            def classifier = matcher.group('classifier')
+            /* Set the relative path to change the destination, since 
+             * Gradle doesn't seem to like the absolute path being set*/
+            it.relativePath = it.relativePath.parent.append(false, classifier, it.name)
+        }
     }
-    into file("${config.dir_output}/deobf")
-}
-
-task sort(type: Delete) {
-    dependsOn "outputDeobf"
-    delete "${config.dir_output}/${deobfJar.archiveName}", "${config.dir_output}/wtf"
 }
 
 def parseConfig(File config) {
@@ -145,4 +150,4 @@ def parseConfig(File config) {
     }
 }
 
-defaultTasks 'clean', 'build', 'sort', 'incrementBuildNumber'
+defaultTasks 'clean', 'build', 'sortArtifacts', 'incrementBuildNumber'

--- a/src/main/java/vazkii/psi/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/psi/common/crafting/ModCraftingRecipes.java
@@ -20,11 +20,25 @@ import vazkii.psi.common.Psi;
 import vazkii.psi.common.block.base.ModBlocks;
 import vazkii.psi.common.core.handler.ConfigHandler;
 import vazkii.psi.common.item.base.ModItems;
+import vazkii.psi.common.lib.LibPieceNames;
 
 public class ModCraftingRecipes {
 
 	public static void init() {
 		PsiAPI.registerTrickRecipe("", Items.REDSTONE, new ItemStack(ModItems.material), new ItemStack(ModItems.cadAssembly));
+
+		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_INFUSION, "ingotGold",
+				new ItemStack(ModItems.material, 1, 1), 
+				new ItemStack(ModItems.cadAssembly));
+		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_GREATER_INFUSION, "gemDiamond",
+				new ItemStack(ModItems.material, 1, 2), 
+				new ItemStack(ModItems.cadAssembly, 1, 2));
+		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY, new ItemStack(Items.COAL),
+				new ItemStack(ModItems.material, 1, 5), 
+				new ItemStack(ModItems.cadAssembly, 1, 2));
+		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY, "gemQuartz",
+				new ItemStack(ModItems.material, 1, 6), 
+				new ItemStack(ModItems.cadAssembly, 1, 2));
 
 		if(Psi.magical && !ConfigHandler.magipsiClientSide)
 			return;

--- a/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickEbonyIvory.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickEbonyIvory.java
@@ -18,21 +18,8 @@ import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.piece.PieceTrick;
 import vazkii.psi.common.item.ItemCAD;
 import vazkii.psi.common.item.base.ModItems;
-import vazkii.psi.common.lib.LibPieceNames;
 
 public class PieceTrickEbonyIvory extends PieceTrick {
-
-	static {
-		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY,
-				new ItemStack(Items.COAL),
-				new ItemStack(ModItems.material, 1, 5),
-				new ItemStack(ModItems.cadAssembly, 1, 2));
-		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY,
-				"gemQuartz",
-				new ItemStack(ModItems.material, 1, 6),
-				new ItemStack(ModItems.cadAssembly, 1, 2));
-	}
-
 	public PieceTrickEbonyIvory(Spell spell) {
 		super(spell);
 	}

--- a/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickGreaterInfusion.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickGreaterInfusion.java
@@ -16,17 +16,8 @@ import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.piece.PieceTrick;
 import vazkii.psi.common.item.ItemCAD;
 import vazkii.psi.common.item.base.ModItems;
-import vazkii.psi.common.lib.LibPieceNames;
 
 public class PieceTrickGreaterInfusion extends PieceTrick {
-
-	static {
-		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_GREATER_INFUSION,
-				"gemDiamond",
-				new ItemStack(ModItems.material, 1, 2),
-				new ItemStack(ModItems.cadAssembly, 1, 2));
-	}
-
 	public PieceTrickGreaterInfusion(Spell spell) {
 		super(spell);
 	}

--- a/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickInfusion.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/infusion/PieceTrickInfusion.java
@@ -16,17 +16,8 @@ import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.piece.PieceTrick;
 import vazkii.psi.common.item.ItemCAD;
 import vazkii.psi.common.item.base.ModItems;
-import vazkii.psi.common.lib.LibPieceNames;
 
 public class PieceTrickInfusion extends PieceTrick {
-
-	static {
-		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_INFUSION,
-				"ingotGold",
-				new ItemStack(ModItems.material, 1, 1),
-				new ItemStack(ModItems.cadAssembly));
-	}
-
 	public PieceTrickInfusion(Spell spell) {
 		super(spell);
 	}


### PR DESCRIPTION
Gradle stuff taken from Vazkii/Patchouli#2, and my port of it to Botania. Deobf jars are passe, but if you want, feel free to put that back in. 

Moves trick recipe registration to crafting recipes because it turns out class literals don't classload reliably and it would only happen once you opened the spellpiece selection in the programmer, requiring a resource reload to put them in JEI.