### PR TITLE
Fix break tool and level

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellContext.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellContext.java
@@ -30,6 +30,10 @@ import java.util.Stack;
  */
 public final class SpellContext {
 
+	public SpellContext(ItemStack cad) {
+		this.cad = cad;
+	}
+
 	/**
 	 * The maximum distance from the spell's {@link #focalPoint} a piece of the spell can interact with.<br>
 	 * This should be checked against in any tricks that affect parts of the world given a position
@@ -37,7 +41,10 @@ public final class SpellContext {
 	 * @see #isInRadius(Entity), {@link #isInRadius(Vector3)}, {@link #isInRadius(double, double, double)}
 	 */
 	public static final double MAX_DISTANCE = 32;
-
+	/**
+	 * The CAD used to cast this spell.
+	 */
+	public ItemStack cad;
 	/**
 	 * The player casting this spell.
 	 */

--- a/src/main/java/vazkii/psi/api/spell/SpellContext.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellContext.java
@@ -41,10 +41,12 @@ public final class SpellContext {
 	 * @see #isInRadius(Entity), {@link #isInRadius(Vector3)}, {@link #isInRadius(double, double, double)}
 	 */
 	public static final double MAX_DISTANCE = 32;
+
 	/**
 	 * The CAD used to cast this spell.
 	 */
 	public ItemStack cad;
+
 	/**
 	 * The player casting this spell.
 	 */

--- a/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
+++ b/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
@@ -18,6 +18,8 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import vazkii.psi.api.cad.EnumCADComponent;
+import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
 import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.common.Psi;
@@ -45,9 +47,14 @@ public class RenderSpellCircle extends Render<EntitySpellCircle> {
 		super.doRender(entity, x, y, z, entityYaw, partialTicks);
 
 		int colorVal = ICADColorizer.DEFAULT_SPELL_COLOR;
-		ItemStack colorizer = entity.getDataManager().get(EntitySpellCircle.COLORIZER_DATA);
-		if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
-			colorVal = Psi.proxy.getColorForColorizer(colorizer);
+
+		ItemStack cad = entity.getDataManager().get(EntitySpellCircle.CAD_DATA);
+		if(!cad.isEmpty() && cad.getItem() instanceof ICAD) {
+			ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
+			if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
+				colorVal = Psi.proxy.getColorForColorizer(colorizer);
+		}
+
 		float alive = entity.getTimeAlive() + partialTicks;
 		float s1 = Math.min(1F, alive / EntitySpellCircle.CAST_DELAY);
 		if(alive > EntitySpellCircle.LIVE_TIME - EntitySpellCircle.CAST_DELAY)

--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -409,7 +409,7 @@ public class PlayerDataHandler {
 
 						ISpellAcceptor spellContainer = ISpellAcceptor.acceptor(bullet);
 						Spell spell = spellContainer.getSpell();
-						SpellContext context = new SpellContext().setPlayer(player).setSpell(spell).setLoopcastIndex(loopcastAmount + 1);
+						SpellContext context = new SpellContext(cadStack).setPlayer(player).setSpell(spell).setLoopcastIndex(loopcastAmount + 1);
 						if(context.isValid()) {
 							if(context.cspell.metadata.evaluateAgainst(cadStack)) {
 								int cost = ItemCAD.getRealCost(cadStack, bullet, context.cspell.metadata.stats.get(EnumSpellStat.COST));

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
@@ -24,11 +24,8 @@ import net.minecraft.world.World;
 import vazkii.psi.api.cad.EnumCADComponent;
 import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
+import vazkii.psi.api.spell.*;
 import vazkii.psi.api.internal.PsiRenderHelper;
-import vazkii.psi.api.spell.ISpellAcceptor;
-import vazkii.psi.api.spell.ISpellImmune;
-import vazkii.psi.api.spell.Spell;
-import vazkii.psi.api.spell.SpellContext;
 import vazkii.psi.common.Psi;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
@@ -21,9 +21,14 @@ import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import vazkii.psi.api.cad.EnumCADComponent;
+import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
-import vazkii.psi.api.spell.*;
 import vazkii.psi.api.internal.PsiRenderHelper;
+import vazkii.psi.api.spell.ISpellAcceptor;
+import vazkii.psi.api.spell.ISpellImmune;
+import vazkii.psi.api.spell.Spell;
+import vazkii.psi.api.spell.SpellContext;
 import vazkii.psi.common.Psi;
 
 import javax.annotation.Nonnull;
@@ -35,7 +40,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 	public static final int CAST_DELAY = 5;
 	public static final int LIVE_TIME = (CAST_TIMES + 2) * CAST_DELAY;
 
-	private static final String TAG_COLORIZER = "colorizer";
+	private static final String TAG_CAD = "cad";
 	private static final String TAG_BULLET = "bullet";
 	private static final String TAG_CASTER = "caster";
 	private static final String TAG_TIME_ALIVE = "timeAlive";
@@ -46,7 +51,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 	private static final String TAG_LOOK_Z = "savedLookZ";
 
 	// Generics are borked :|
-	public static final DataParameter<ItemStack> COLORIZER_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
+	public static final DataParameter<ItemStack> CAD_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<ItemStack> BULLET_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<String> CASTER_NAME = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.STRING);
 	private static final DataParameter<Integer> TIME_ALIVE = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.VARINT);
@@ -61,8 +66,8 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 		setSize(3F, 0F);
 	}
 
-	public EntitySpellCircle setInfo(EntityPlayer player, ItemStack colorizer, ItemStack bullet) {
-		dataManager.set(COLORIZER_DATA,colorizer);
+	public EntitySpellCircle setInfo(EntityPlayer player, ItemStack cad, ItemStack bullet) {
+		dataManager.set(CAD_DATA, cad);
 		dataManager.set(BULLET_DATA, bullet);
 		dataManager.set(CASTER_NAME, player.getName());
 
@@ -75,7 +80,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	protected void entityInit() {
-		dataManager.register(COLORIZER_DATA, new ItemStack(Blocks.STONE));
+		dataManager.register(CAD_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(BULLET_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(CASTER_NAME, "");
 		dataManager.register(TIME_ALIVE, 0);
@@ -87,11 +92,11 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	public void writeEntityToNBT(@Nonnull NBTTagCompound tagCompound) {
-		NBTTagCompound colorizerCmp = new NBTTagCompound();
-		ItemStack colorizer =  dataManager.get(COLORIZER_DATA);
-		if (!colorizer.isEmpty())
-			colorizer.writeToNBT(colorizerCmp);
-		tagCompound.setTag(TAG_COLORIZER, colorizerCmp);
+		NBTTagCompound cadCmp = new NBTTagCompound();
+		ItemStack cad = dataManager.get(CAD_DATA);
+		if(!cad.isEmpty())
+			cad.writeToNBT(cadCmp);
+		tagCompound.setTag(TAG_CAD, cadCmp);
 
 		NBTTagCompound bulletCmp = new NBTTagCompound();
 		ItemStack bullet = dataManager.get(BULLET_DATA);
@@ -110,9 +115,9 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	public void readEntityFromNBT(@Nonnull NBTTagCompound tagCompound) {
-		NBTTagCompound colorizerCmp = tagCompound.getCompoundTag(TAG_COLORIZER);
-		ItemStack colorizer = new ItemStack(colorizerCmp);
-		dataManager.set(COLORIZER_DATA, colorizer);
+		NBTTagCompound cadCmp = tagCompound.getCompoundTag(TAG_CAD);
+		ItemStack cad = new ItemStack(cadCmp);
+		dataManager.set(CAD_DATA, cad);
 
 		NBTTagCompound bulletCmp = tagCompound.getCompoundTag(TAG_BULLET);
 		ItemStack bullet = new ItemStack(bulletCmp);
@@ -137,6 +142,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 		setTimeAlive(timeAlive + 1);
 		int times = dataManager.get(TIMES_CAST);
+		ItemStack cad = dataManager.get(CAD_DATA);
 
 		if (timeAlive > CAST_DELAY && timeAlive % CAST_DELAY == 0 && times < 20) {
 			SpellContext context = null;
@@ -147,7 +153,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 					dataManager.set(TIMES_CAST, times + 1);
 					Spell spell = ISpellAcceptor.acceptor(spellContainer).getSpell();
 					if (spell != null)
-						context = new SpellContext().setPlayer((EntityPlayer) thrower).setFocalPoint(this)
+						context = new SpellContext(cad).setPlayer((EntityPlayer) thrower).setFocalPoint(this)
 								.setSpell(spell).setLoopcastIndex(times);
 				}
 			}
@@ -157,9 +163,12 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 		}
 
 		int colorVal = ICADColorizer.DEFAULT_SPELL_COLOR;
-		ItemStack colorizer = dataManager.get(COLORIZER_DATA);
-		if (!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
-			colorVal = Psi.proxy.getColorForColorizer(colorizer);
+		if(!cad.isEmpty() && cad.getItem() instanceof ICAD) {
+			ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
+			if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
+				colorVal = Psi.proxy.getColorForColorizer(colorizer);
+		}
+
 
 		float r = PsiRenderHelper.r(colorVal) / 255F;
 		float g = PsiRenderHelper.g(colorVal) / 255F;

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
@@ -22,12 +22,14 @@ import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
+import vazkii.psi.api.cad.EnumCADComponent;
+import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
+import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.ISpellAcceptor;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
-import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.common.Psi;
 
 import javax.annotation.Nonnull;
@@ -36,7 +38,7 @@ import java.util.function.Consumer;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class EntitySpellProjectile extends EntityThrowable {
 
-	private static final String TAG_COLORIZER = "colorizer";
+	private static final String TAG_CAD = "cad";
 	private static final String TAG_BULLET = "bullet";
 	private static final String TAG_TIME_ALIVE = "timeAlive";
 
@@ -44,7 +46,7 @@ public class EntitySpellProjectile extends EntityThrowable {
 	private static final String TAG_LAST_MOTION_Y = "lastMotionY";
 	private static final String TAG_LAST_MOTION_Z = "lastMotionZ";
 
-	private static final DataParameter<ItemStack> COLORIZER_DATA = EntityDataManager.createKey(EntitySpellProjectile.class, DataSerializers.ITEM_STACK);
+	private static final DataParameter<ItemStack> CAD_DATA = EntityDataManager.createKey(EntitySpellProjectile.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<ItemStack> BULLET_DATA = EntityDataManager.createKey(EntitySpellProjectile.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<String> CASTER_NAME = EntityDataManager.createKey(EntitySpellProjectile.class, DataSerializers.STRING);
 
@@ -66,8 +68,8 @@ public class EntitySpellProjectile extends EntityThrowable {
 		motionZ *= speed;
 	}
 
-	public EntitySpellProjectile setInfo(EntityPlayer player, ItemStack colorizer, ItemStack bullet) {
-		dataManager.set(COLORIZER_DATA, colorizer);
+	public EntitySpellProjectile setInfo(EntityPlayer player, ItemStack cad, ItemStack bullet) {
+		dataManager.set(CAD_DATA, cad);
 		dataManager.set(BULLET_DATA, bullet);
 		dataManager.set(CASTER_NAME, player.getName());
 		return this;
@@ -75,7 +77,7 @@ public class EntitySpellProjectile extends EntityThrowable {
 
 	@Override
 	protected void entityInit() {
-		dataManager.register(COLORIZER_DATA, new ItemStack(Blocks.STONE));
+		dataManager.register(CAD_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(BULLET_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(CASTER_NAME, "");
 	}
@@ -84,11 +86,11 @@ public class EntitySpellProjectile extends EntityThrowable {
 	public void writeEntityToNBT(NBTTagCompound tagCompound) {
 		super.writeEntityToNBT(tagCompound);
 
-		NBTTagCompound colorizerCmp = new NBTTagCompound();
-		ItemStack colorizer = dataManager.get(COLORIZER_DATA);
-		if(!colorizer.isEmpty())
-			colorizer.writeToNBT(colorizerCmp);
-		tagCompound.setTag(TAG_COLORIZER, colorizerCmp);
+		NBTTagCompound cadCmp = new NBTTagCompound();
+		ItemStack cad = dataManager.get(CAD_DATA);
+		if(!cad.isEmpty())
+			cad.writeToNBT(cadCmp);
+		tagCompound.setTag(TAG_CAD, cadCmp);
 
 		NBTTagCompound bulletCmp = new NBTTagCompound();
 		ItemStack bullet = dataManager.get(BULLET_DATA);
@@ -107,9 +109,9 @@ public class EntitySpellProjectile extends EntityThrowable {
 	public void readEntityFromNBT(NBTTagCompound tagCompound) {
 		super.readEntityFromNBT(tagCompound);
 
-		NBTTagCompound colorizerCmp = tagCompound.getCompoundTag(TAG_COLORIZER);
-		ItemStack colorizer = new ItemStack(colorizerCmp);
-		dataManager.set(COLORIZER_DATA, colorizer);
+		NBTTagCompound cadCmp = tagCompound.getCompoundTag(TAG_CAD);
+		ItemStack cad = new ItemStack(cadCmp);
+		dataManager.set(CAD_DATA, cad);
 
 		NBTTagCompound bulletCmp = tagCompound.getCompoundTag(TAG_BULLET);
 		ItemStack bullet = new ItemStack(bulletCmp);
@@ -138,9 +140,12 @@ public class EntitySpellProjectile extends EntityThrowable {
 			setDead();
 		
 		int colorVal = ICADColorizer.DEFAULT_SPELL_COLOR;
-		ItemStack colorizer = dataManager.get(COLORIZER_DATA);
-		if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
-			colorVal = Psi.proxy.getColorForColorizer(colorizer);
+		ItemStack cad = dataManager.get(CAD_DATA);
+		if(!cad.isEmpty() && cad.getItem() instanceof ICAD) {
+			ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
+			if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
+				colorVal = Psi.proxy.getColorForColorizer(colorizer);
+		}
 
 		float r = PsiRenderHelper.r(colorVal) / 255F;
 		float g = PsiRenderHelper.g(colorVal) / 255F;
@@ -199,13 +204,15 @@ public class EntitySpellProjectile extends EntityThrowable {
 		boolean canCast = false;
 
 		if(thrower instanceof EntityPlayer) {
+			EntityPlayer player = (EntityPlayer) thrower;
+			ItemStack cad = dataManager.get(CAD_DATA);
 			ItemStack spellContainer = dataManager.get(BULLET_DATA);
 			if (!spellContainer.isEmpty() && ISpellAcceptor.isContainer(spellContainer)) {
 				Spell spell = ISpellAcceptor.acceptor(spellContainer).getSpell();
 				if(spell != null) {
 					canCast = true;
 					if(context == null)
-						context = new SpellContext().setPlayer((EntityPlayer) thrower).setFocalPoint(this).setSpell(spell);
+						context = new SpellContext(cad).setPlayer(player).setFocalPoint(this).setSpell(spell);
 					context.setFocalPoint(this);
 				}
 			}

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellProjectile.java
@@ -25,11 +25,11 @@ import net.minecraft.world.World;
 import vazkii.psi.api.cad.EnumCADComponent;
 import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
-import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.ISpellAcceptor;
 import vazkii.psi.api.spell.Spell;
 import vazkii.psi.api.spell.SpellContext;
+import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.common.Psi;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -204,7 +204,7 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		if (!data.overflowed && data.getAvailablePsi() > 0 && !cad.isEmpty() && !bullet.isEmpty() && ISpellAcceptor.hasSpell(bullet) && isTruePlayer(player)) {
 			ISpellAcceptor spellContainer = ISpellAcceptor.acceptor(bullet);
 			Spell spell = spellContainer.getSpell();
-			SpellContext context = new SpellContext().setPlayer(player).setSpell(spell);
+			SpellContext context = new SpellContext(cad).setPlayer(player).setSpell(spell);
 			if (predicate != null)
 				predicate.accept(context);
 

--- a/src/main/java/vazkii/psi/common/item/ItemSpellBullet.java
+++ b/src/main/java/vazkii/psi/common/item/ItemSpellBullet.java
@@ -26,8 +26,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.item.ItemMod;
 import vazkii.arl.util.ItemNBTHelper;
 import vazkii.psi.api.PsiAPI;
-import vazkii.psi.api.cad.EnumCADComponent;
-import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.internal.TooltipHelper;
 import vazkii.psi.api.spell.ISpellContainer;
 import vazkii.psi.api.spell.Spell;
@@ -140,7 +138,6 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 	@Override
 	public void castSpell(ItemStack stack, SpellContext context) {
 		ItemStack cad = PsiAPI.getPlayerCAD(context.caster);
-		ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
 
 		EntitySpellProjectile projectile = null;
 
@@ -171,7 +168,7 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 
 				if (pos != null) {
 					EntitySpellCircle circle = new EntitySpellCircle(context.caster.getEntityWorld());
-					circle.setInfo(context.caster, colorizer, stack);
+					circle.setInfo(context.caster, cad, stack);
 					circle.setPosition(pos.hitVec.x, pos.hitVec.y, pos.hitVec.z);
 					circle.getEntityWorld().spawnEntity(circle);
 				}
@@ -192,7 +189,7 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 		}
 
 		if (projectile != null) {
-			projectile.setInfo(context.caster, colorizer, stack);
+			projectile.setInfo(context.caster, cad, stack);
 			projectile.context = context;
 			projectile.getEntityWorld().spawnEntity(projectile);
 		}

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -63,8 +63,18 @@ public class PieceTrickBreakBlock extends PieceTrick {
 		if(!context.isInRadius(positionVal))
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
+		ItemStack tool = context.tool;
+		if(tool.isEmpty()) {
+			tool = PsiAPI.getPlayerCAD(context.caster);
+			if(tool.isEmpty()) {
+				tool = context.cad;
+				if(tool.isEmpty())
+					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
+			}
+		}
+
 		BlockPos pos = positionVal.toBlockPos();
-		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), context.tool, pos, true);
+		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), tool, pos, true);
 
 		return null;
 	}
@@ -72,9 +82,6 @@ public class PieceTrickBreakBlock extends PieceTrick {
 	public static void removeBlockWithDrops(SpellContext context, EntityPlayer player, World world, ItemStack tool, BlockPos pos, boolean particles) {
 		if(!world.isBlockLoaded(pos) || (context.positionBroken != null && pos.equals(context.positionBroken.getBlockPos())) || !world.isBlockModifiable(player, pos))
 			return;
-
-		if (tool.isEmpty())
-			tool = PsiAPI.getPlayerCAD(player);
 
 		IBlockState state = world.getBlockState(pos);
 		Block block = state.getBlock();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
@@ -56,8 +56,14 @@ public class PieceTrickCollapseBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 		ItemStack tool = context.tool;
-		if (tool.isEmpty())
+		if(tool.isEmpty()) {
 			tool = PsiAPI.getPlayerCAD(context.caster);
+			if(tool.isEmpty()) {
+				tool = context.cad;
+				if(tool.isEmpty())
+					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
+			}
+		}
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -58,8 +58,14 @@ public class PieceTrickMoveBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 		ItemStack tool = context.tool;
-		if (tool.isEmpty())
+		if(tool.isEmpty()) {
 			tool = PsiAPI.getPlayerCAD(context.caster);
+			if(tool.isEmpty()) {
+				tool = context.cad;
+				if(tool.isEmpty())
+					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
+			}
+		}
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -73,7 +73,7 @@ public class PieceTrickMoveBlock extends PieceTrick {
 		Block block = state.getBlock();
 		if(world.getTileEntity(pos) != null || state.getPushReaction() != EnumPushReaction.NORMAL ||
 				!block.canSilkHarvest(world, pos, state, context.caster) ||
-				state.getPlayerRelativeBlockHardness(context.caster, world, pos) <= 0 ||
+				state.getBlockHardness(world, pos) <= 0 ||
 				!PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, pos, tool))
 			return null;
 		


### PR DESCRIPTION
## Summary
Addresses some of the problems described in #537 
Namely, the CAD being able to harvest blocks that ordinarily require special tools (like Forestry Hives)
Also when a spell is cast, the CAD stack is part of the context, also is saved in projectile and spell circle so it is more likely to be available for the break block spell.
I'm not really happy with the current PR / implementation though so looking for comments and discussion about how it could be changed.

## PR Changes
- Have the CAD stack used to cast a spell available in the spell context
- Makes sure that the CAD acts only as a pickxe, axe and shovel
- Makes sure that the CAD or psimetal tool that casted the spell is used to check harvestability (not the main hand). Before this change it only checked harvest level.
- Makes sure that we use `return new ForgeEventFactory:doPlayerHarvestCheck` mirroring `ForgeHooks::canHarvestBlock` letting the event system decide the fate if the harvest
- Note: Harvest tool classes and harvest levels for vanilla blocks are set properly by forge (See: `ForgeHooks::initTools()`) so harvest levels >= 3 properly harvest obsidian.

## Testing Environment

AutoRegLib-1.3-32
forestry_1.12.2-5.8.2.387
jei_1.12.2-4.15.0.291
Psi-r1.1-77

## Demo Videos and Summary

[Before](https://www.youtube.com/watch?v=EDz9URi3ffk)
- All tools and CAD harvest Planks, Dirt, Stone, Coal, Iron, Diamond and **Forestry Hive**
- Psimetal pickaxe also harvests obsidian
- No tools harvest bedrock

[After](https://www.youtube.com/watch?v=-Bf9ZmWXWrA)
- All tools harvest Planks and Dirt
- Psimetal pickaxe also harvests Stone, Coal, Iron, Diamond
- No tools harvest bedrock or Forestry Hives

## Other thoughts

Adding the CAD into spell context and saving it in projectile spells and spell circles is quite an intrustive change. A much simpler solution might be to just have break block fail if it can't find a CAD or tool to use? I think I may just change this PR to be that instead tbh. It would touch way less code that way.