### PR TITLE
Use GLStateManager over glPopAttrib / glPushAttrib

### DIFF
--- a/src/main/java/vazkii/psi/client/fx/ParticleRenderDispatcher.java
+++ b/src/main/java/vazkii/psi/client/fx/ParticleRenderDispatcher.java
@@ -37,7 +37,7 @@ public final class ParticleRenderDispatcher {
 
 		Profiler profiler = Minecraft.getMinecraft().profiler;
 
-		GL11.glPushAttrib(GL11.GL_LIGHTING);
+		boolean lighting = GL11.glIsEnabled(GL11.GL_LIGHTING);
 		GlStateManager.depthMask(false);
 		GlStateManager.enableBlend();
 		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
@@ -56,7 +56,8 @@ public final class ParticleRenderDispatcher {
 		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GlStateManager.disableBlend();
 		GlStateManager.depthMask(true);
-		GL11.glPopAttrib();
+		if (lighting)
+			GlStateManager.enableLighting();
 	}
 
 }


### PR DESCRIPTION
Using glPopAttrib and glPushAttrib can cause GLStateManager to become out of sync with the real OpenGL state. This means that GLStateManager will not update the real OpenGL state correctly which can cause graphical glitches in other mods. See Electroblob77/Wizardry#170.

Should fix Vazkii/Psi#525