### PR TITLE
Finish recipe generation

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/storage_blocks/ebony_psimetal.json
+++ b/src/generated/resources/data/forge/tags/blocks/storage_blocks/ebony_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ebony_psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/storage_blocks/ivory_psimetal.json
+++ b/src/generated/resources/data/forge/tags/blocks/storage_blocks/ivory_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ivory_psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/storage_blocks/psigem.json
+++ b/src/generated/resources/data/forge/tags/blocks/storage_blocks/psigem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psigem_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/storage_blocks/psimetal.json
+++ b/src/generated/resources/data/forge/tags/blocks/storage_blocks/psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/gems/psigem.json
+++ b/src/generated/resources/data/forge/tags/items/gems/psigem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psigem"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/ingots/ebony_psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/ingots/ebony_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ebony_psimetal"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/ingots/ivory_psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/ingots/ivory_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ivory_psimetal"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/ingots/psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/ingots/psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psimetal"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/storage_blocks/ebony_psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/storage_blocks/ebony_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ebony_psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/storage_blocks/ivory_psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/storage_blocks/ivory_psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ivory_psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/storage_blocks/psigem.json
+++ b/src/generated/resources/data/forge/tags/items/storage_blocks/psigem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psigem_block"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/storage_blocks/psimetal.json
+++ b/src/generated/resources/data/forge/tags/items/storage_blocks/psimetal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psimetal_block"
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/assembler.json
+++ b/src/generated/resources/data/psi/advancements/recipe/assembler.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:assembler"
+          ]
+        },
+        "criteria": {
+          "has_iron": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/iron"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:assembler"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_iron",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_assembly_ebony.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_assembly_ebony.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_assembly_ebony"
+          ]
+        },
+        "criteria": {
+          "has_ebony_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ebony_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_assembly_ebony"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ebony_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_assembly_gold.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_assembly_gold.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_assembly_gold"
+          ]
+        },
+        "criteria": {
+          "has_gold": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/gold"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_assembly_gold"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_gold",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_assembly_iron.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_assembly_iron.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_assembly_iron"
+          ]
+        },
+        "criteria": {
+          "has_iron": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/iron"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_assembly_iron"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_iron",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_assembly_ivory.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_assembly_ivory.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_assembly_ivory"
+          ]
+        },
+        "criteria": {
+          "has_ivory_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ivory_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_assembly_ivory"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ivory_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_assembly_psimetal.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_assembly_psimetal.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_assembly_psimetal"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_assembly_psimetal"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_battery_basic.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_battery_basic.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_battery_basic"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_battery_basic"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_battery_extended.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_battery_extended.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_battery_extended"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_battery_extended"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_battery_ultradense.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_battery_ultradense.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_battery_ultradense"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_battery_ultradense"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_black.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_black.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_black"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_black"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_blue.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_blue.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_blue"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_blue"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_brown.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_brown.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_brown"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_brown"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_cyan.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_cyan.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_cyan"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_cyan"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_gray.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_gray.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_gray"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_gray"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_green.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_green.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_green"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_green"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_light_blue.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_light_blue.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_light_blue"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_light_blue"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_light_gray.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_light_gray.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_light_gray"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_light_gray"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_lime.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_lime.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_lime"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_lime"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_magenta.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_magenta.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_magenta"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_magenta"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_orange.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_orange.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_orange"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_orange"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_pink.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_pink.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_pink"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_pink"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_psi.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_psi.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_psi"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_psi"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_purple.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_purple.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_purple"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_purple"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_rainbow.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_rainbow.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_rainbow"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_rainbow"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_red.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_red.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_red"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_red"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_white.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_white.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_white"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_white"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_yellow.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_colorizer_yellow.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_colorizer_yellow"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_colorizer_yellow"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_core_basic.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_core_basic.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_core_basic"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_core_basic"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_core_conductive.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_core_conductive.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_core_conductive"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_core_conductive"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_core_hyperclocked.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_core_hyperclocked.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_core_hyperclocked"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_core_hyperclocked"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_core_overclocked.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_core_overclocked.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_core_overclocked"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_core_overclocked"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_core_radiative.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_core_radiative.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_core_radiative"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_core_radiative"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_socket_basic.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_socket_basic.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_socket_basic"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_socket_basic"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_socket_huge.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_socket_huge.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_socket_huge"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_socket_huge"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_socket_large.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_socket_large.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_socket_large"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_socket_large"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_socket_signaling.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_socket_signaling.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_socket_signaling"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_socket_signaling"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/cad_socket_transmissive.json
+++ b/src/generated/resources/data/psi/advancements/recipe/cad_socket_transmissive.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:cad_socket_transmissive"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:cad_socket_transmissive"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/detonator.json
+++ b/src/generated/resources/data/psi/advancements/recipe/detonator.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:detonator"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:detonator"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ebony_block.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ebony_block.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ebony_block"
+          ]
+        },
+        "criteria": {
+          "has_ebony_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ebony_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ebony_block"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ebony_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ebony_block_shapeless.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ebony_block_shapeless.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ebony_block_shapeless"
+          ]
+        },
+        "criteria": {
+          "has_ebony_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ebony_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ebony_block_shapeless"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ebony_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ebony_psimetal.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ebony_psimetal.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ebony_psimetal"
+          ]
+        },
+        "criteria": {
+          "has_ebony_substance": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "item": "psi:ebony_substance"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ebony_psimetal"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ebony_substance",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/exosuit_controller.json
+++ b/src/generated/resources/data/psi/advancements/recipe/exosuit_controller.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:exosuit_controller"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:exosuit_controller"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_heat.json
+++ b/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_heat.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:exosuit_sensor_heat"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:exosuit_sensor_heat"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_light.json
+++ b/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_light.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:exosuit_sensor_light"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:exosuit_sensor_light"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_stress.json
+++ b/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_stress.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:exosuit_sensor_stress"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:exosuit_sensor_stress"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_water.json
+++ b/src/generated/resources/data/psi/advancements/recipe/exosuit_sensor_water.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:exosuit_sensor_water"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:exosuit_sensor_water"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ivory_block.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ivory_block.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ivory_block"
+          ]
+        },
+        "criteria": {
+          "has_ivory_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ivory_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ivory_block"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ivory_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ivory_block_shapeless.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ivory_block_shapeless.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ivory_block_shapeless"
+          ]
+        },
+        "criteria": {
+          "has_ivory_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/ivory_psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ivory_block_shapeless"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ivory_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/ivory_psimetal.json
+++ b/src/generated/resources/data/psi/advancements/recipe/ivory_psimetal.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:ivory_psimetal"
+          ]
+        },
+        "criteria": {
+          "has_ivory_substance": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "item": "psi:ivory_substance"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:ivory_psimetal"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_ivory_substance",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/programmer.json
+++ b/src/generated/resources/data/psi/advancements/recipe/programmer.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:programmer"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:programmer"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psidust_block.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psidust_block.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psidust_block"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psidust_block"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psidust_block_shapeless.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psidust_block_shapeless.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psidust_block_shapeless"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psidust_block_shapeless"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psigem_block.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psigem_block.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psigem_block"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psigem_block"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psigem_block_shapeless.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psigem_block_shapeless.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psigem_block_shapeless"
+          ]
+        },
+        "criteria": {
+          "has_psigem": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "item": "psi:psigem"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psigem_block_shapeless"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psigem",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_axe.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_axe.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_axe"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_axe"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_block.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_block.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_block"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_block"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_block_shapeless.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_block_shapeless.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_block_shapeless"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_block_shapeless"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_boots.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_boots.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_exosuit_boots"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_exosuit_boots"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_chestplate.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_chestplate.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_exosuit_chestplate"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_exosuit_chestplate"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_helmet.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_helmet.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_exosuit_helmet"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_exosuit_helmet"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_leggings.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_exosuit_leggings.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_exosuit_leggings"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_exosuit_leggings"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_pickaxe.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_pickaxe.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_pickaxe"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_pickaxe"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_black.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_black.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_plate_black"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_plate_black"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_black_light.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_black_light.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_plate_black_light"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_plate_black_light"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_white.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_white.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_plate_white"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_plate_white"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_white_light.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_plate_white_light.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_plate_white_light"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_plate_white_light"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_shovel.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_shovel.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_shovel"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_shovel"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/psimetal_sword.json
+++ b/src/generated/resources/data/psi/advancements/recipe/psimetal_sword.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:psimetal_sword"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:psimetal_sword"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_basic.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_basic.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_basic"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_basic"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_charge.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_charge.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_charge"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_charge"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_circle.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_circle.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_circle"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_circle"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_grenade.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_grenade.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_grenade"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_grenade"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_loopcast.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_loopcast.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_loopcast"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_loopcast"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_mine.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_mine.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_mine"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_mine"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_bullet_projectile.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_bullet_projectile.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_bullet_projectile"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_bullet_projectile"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/spell_drive.json
+++ b/src/generated/resources/data/psi/advancements/recipe/spell_drive.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:spell_drive"
+          ]
+        },
+        "criteria": {
+          "has_psimetal": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "forge:ingots/psimetal"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:spell_drive"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psimetal",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/advancements/recipe/vector_ruler.json
+++ b/src/generated/resources/data/psi/advancements/recipe/vector_ruler.json
@@ -1,0 +1,46 @@
+{
+  "advancements": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "advancement": {
+        "parent": "minecraft:recipes/root",
+        "rewards": {
+          "recipes": [
+            "psi:vector_ruler"
+          ]
+        },
+        "criteria": {
+          "has_psidust": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+              "items": [
+                {
+                  "tag": "psi:psidust"
+                }
+              ]
+            }
+          },
+          "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+              "recipe": "psi:vector_ruler"
+            }
+          }
+        },
+        "requirements": [
+          [
+            "has_psidust",
+            "has_the_recipe"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/assembler.json
+++ b/src/generated/resources/data/psi/recipes/assembler.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "IPI",
+          "I I",
+          " I "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "P": {
+            "item": "minecraft:piston"
+          }
+        },
+        "result": {
+          "item": "psi:cad_assembler"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_assembly_ebony.json
+++ b/src/generated/resources/data/psi/recipes/cad_assembly_ebony.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "III",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/ebony_psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:cad_assembly_ivory_psimetal"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_assembly_gold.json
+++ b/src/generated/resources/data/psi/recipes/cad_assembly_gold.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "III",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/gold"
+          }
+        },
+        "result": {
+          "item": "psi:cad_assembly_gold"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_assembly_iron.json
+++ b/src/generated/resources/data/psi/recipes/cad_assembly_iron.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "III",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:cad_assembly_iron"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_assembly_ivory.json
+++ b/src/generated/resources/data/psi/recipes/cad_assembly_ivory.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "III",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/ivory_psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:cad_ivory_psimetal"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_assembly_psimetal.json
+++ b/src/generated/resources/data/psi/recipes/cad_assembly_psimetal.json
@@ -1,0 +1,30 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "III",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:cad_assembly_psimetal"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_battery_basic.json
+++ b/src/generated/resources/data/psi/recipes/cad_battery_basic.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "I",
+          "D",
+          "G"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "G": {
+            "tag": "forge:ingots/gold"
+          }
+        },
+        "result": {
+          "item": "psi:cad_battery_basic"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_battery_extended.json
+++ b/src/generated/resources/data/psi/recipes/cad_battery_extended.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "I",
+          "D",
+          "G"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:ingots/gold"
+          }
+        },
+        "result": {
+          "item": "psi:cad_battery_extended"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_battery_ultradense.json
+++ b/src/generated/resources/data/psi/recipes/cad_battery_ultradense.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "I",
+          "D",
+          "G"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "forge:gems/psigem"
+          },
+          "G": {
+            "tag": "forge:ingots/gold"
+          }
+        },
+        "result": {
+          "item": "psi:cad_battery_ultradense"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_black.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_black.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/black"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_black"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_blue.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_blue.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/blue"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_blue"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_brown.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_brown.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/brown"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_brown"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_cyan.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_cyan.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/cyan"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_cyan"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_gray.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_gray.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/gray"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_gray"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_green.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_green.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/green"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_green"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_light_blue.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_light_blue.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/light_blue"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_light_blue"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_light_gray.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_light_gray.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/light_gray"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_light_gray"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_lime.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_lime.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/lime"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_lime"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_magenta.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_magenta.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/magenta"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_magenta"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_orange.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_orange.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/orange"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_orange"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_pink.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_pink.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/pink"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_pink"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_psi.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_psi.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_psi"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_purple.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_purple.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/purple"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_purple"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_rainbow.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_rainbow.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:gems/prismarine"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_rainbow"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_red.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_red.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/red"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_red"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_white.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_white.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/white"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_white"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_colorizer_yellow.json
+++ b/src/generated/resources/data/psi/recipes/cad_colorizer_yellow.json
@@ -1,0 +1,41 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "group": "psi:colorizer",
+        "pattern": [
+          " D ",
+          "GCG",
+          " I "
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "C": {
+            "tag": "forge:dyes/yellow"
+          }
+        },
+        "result": {
+          "item": "psi:cad_colorizer_yellow"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_core_basic.json
+++ b/src/generated/resources/data/psi/recipes/cad_core_basic.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IDI",
+          " I "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:cad_core_basic"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_core_conductive.json
+++ b/src/generated/resources/data/psi/recipes/cad_core_conductive.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IDI",
+          " I "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/glowstone"
+          }
+        },
+        "result": {
+          "item": "psi:cad_core_conductive"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_core_hyperclocked.json
+++ b/src/generated/resources/data/psi/recipes/cad_core_hyperclocked.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " G ",
+          "IDI",
+          " G "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/redstone"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:cad_core_hyperclocked"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_core_overclocked.json
+++ b/src/generated/resources/data/psi/recipes/cad_core_overclocked.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IDI",
+          " I "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/redstone"
+          }
+        },
+        "result": {
+          "item": "psi:cad_core_overclocked"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_core_radiative.json
+++ b/src/generated/resources/data/psi/recipes/cad_core_radiative.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " G ",
+          "IDI",
+          " G "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/glowstone"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:cad_core_radiative"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_socket_basic.json
+++ b/src/generated/resources/data/psi/recipes/cad_socket_basic.json
@@ -1,0 +1,33 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "DI ",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:cad_socket_basic"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_socket_huge.json
+++ b/src/generated/resources/data/psi/recipes/cad_socket_huge.json
@@ -1,0 +1,36 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "DI ",
+          "IG "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/glowstone"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:cad_socket_huge"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_socket_large.json
+++ b/src/generated/resources/data/psi/recipes/cad_socket_large.json
@@ -1,0 +1,33 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "DI ",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/glowstone"
+          }
+        },
+        "result": {
+          "item": "psi:cad_socket_large"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_socket_signaling.json
+++ b/src/generated/resources/data/psi/recipes/cad_socket_signaling.json
@@ -1,0 +1,33 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "DI ",
+          "I  "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/redstone"
+          }
+        },
+        "result": {
+          "item": "psi:cad_socket_signaling"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/cad_socket_transmissive.json
+++ b/src/generated/resources/data/psi/recipes/cad_socket_transmissive.json
@@ -1,0 +1,36 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "DI ",
+          "IG "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "D": {
+            "tag": "forge:dusts/redstone"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:cad_socket_transmissive"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/detonator.json
+++ b/src/generated/resources/data/psi/recipes/detonator.json
@@ -1,0 +1,36 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " B ",
+          "IPI"
+        ],
+        "key": {
+          "P": {
+            "tag": "psi:psidust"
+          },
+          "B": {
+            "tag": "minecraft:buttons"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:detonator"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/bullet_to_drive.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/bullet_to_drive.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:bullet_to_drive"
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/colorizer_change.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/colorizer_change.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:colorizer_change"
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/drive_duplicate.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/drive_duplicate.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:drive_duplicate"
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/scavenge.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/scavenge.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:scavenge"
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/sensor_attach.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/sensor_attach.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:sensor_attach"
+}

--- a/src/generated/resources/data/psi/recipes/dynamic/sensor_remove.json
+++ b/src/generated/resources/data/psi/recipes/dynamic/sensor_remove.json
@@ -1,0 +1,3 @@
+{
+  "type": "psi:sensor_remove"
+}

--- a/src/generated/resources/data/psi/recipes/ebony_block.json
+++ b/src/generated/resources/data/psi/recipes/ebony_block.json
@@ -1,0 +1,31 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "OOO",
+          "OOO",
+          "OOO"
+        ],
+        "key": {
+          "O": {
+            "item": "psi:ebony_psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:ebony_psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/ebony_block_shapeless.json
+++ b/src/generated/resources/data/psi/recipes/ebony_block_shapeless.json
@@ -1,0 +1,50 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          },
+          {
+            "item": "psi:ebony_psimetal"
+          }
+        ],
+        "result": {
+          "item": "psi:ebony_psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/ebony_psimetal.json
+++ b/src/generated/resources/data/psi/recipes/ebony_psimetal.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "SSS",
+          "SIS",
+          "SSS"
+        ],
+        "key": {
+          "S": {
+            "tag": "psi:ebony_substance"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:ebony_psimetal"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/exosuit_controller.json
+++ b/src/generated/resources/data/psi/recipes/exosuit_controller.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "R",
+          "G",
+          "I"
+        ],
+        "key": {
+          "R": {
+            "tag": "forge:dusts/redstone"
+          },
+          "G": {
+            "tag": "forge:glass"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:exosuit_controller"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/exosuit_sensor_heat.json
+++ b/src/generated/resources/data/psi/recipes/exosuit_sensor_heat.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IMR",
+          " R "
+        ],
+        "key": {
+          "M": {
+            "item": "minecraft:fire_charge"
+          },
+          "R": {
+            "tag": "forge:ingots/iron"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:exosuit_sensor_heat"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/exosuit_sensor_light.json
+++ b/src/generated/resources/data/psi/recipes/exosuit_sensor_light.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IMR",
+          " R "
+        ],
+        "key": {
+          "M": {
+            "tag": "forge:dusts/glowstone"
+          },
+          "R": {
+            "tag": "forge:ingots/iron"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:exosuit_sensor_light"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/exosuit_sensor_stress.json
+++ b/src/generated/resources/data/psi/recipes/exosuit_sensor_stress.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IMR",
+          " R "
+        ],
+        "key": {
+          "M": {
+            "item": "minecraft:glistering_melon_slice"
+          },
+          "R": {
+            "tag": "forge:ingots/iron"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:exosuit_sensor_stress"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/exosuit_sensor_water.json
+++ b/src/generated/resources/data/psi/recipes/exosuit_sensor_water.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " I ",
+          "IMR",
+          " R "
+        ],
+        "key": {
+          "M": {
+            "tag": "forge:gems/prismarine"
+          },
+          "R": {
+            "tag": "forge:ingots/iron"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:exosuit_sensor_water"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/ivory_block.json
+++ b/src/generated/resources/data/psi/recipes/ivory_block.json
@@ -1,0 +1,31 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "OOO",
+          "OOO",
+          "OOO"
+        ],
+        "key": {
+          "O": {
+            "item": "psi:ivory_psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:ivory_psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/ivory_block_shapeless.json
+++ b/src/generated/resources/data/psi/recipes/ivory_block_shapeless.json
@@ -1,0 +1,50 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          },
+          {
+            "item": "psi:ivory_psimetal"
+          }
+        ],
+        "result": {
+          "item": "psi:ivory_psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/ivory_psimetal.json
+++ b/src/generated/resources/data/psi/recipes/ivory_psimetal.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "SSS",
+          "SIS",
+          "SSS"
+        ],
+        "key": {
+          "S": {
+            "tag": "psi:ivory_substance"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:ivory_psimetal"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/programmer.json
+++ b/src/generated/resources/data/psi/recipes/programmer.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "IDI",
+          "I I",
+          " I "
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:programmer"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psidust_block.json
+++ b/src/generated/resources/data/psi/recipes/psidust_block.json
@@ -1,0 +1,31 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "OOO",
+          "OOO",
+          "OOO"
+        ],
+        "key": {
+          "O": {
+            "item": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:psidust_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psidust_block_shapeless.json
+++ b/src/generated/resources/data/psi/recipes/psidust_block_shapeless.json
@@ -1,0 +1,50 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          },
+          {
+            "item": "psi:psidust"
+          }
+        ],
+        "result": {
+          "item": "psi:psidust_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psigem_block.json
+++ b/src/generated/resources/data/psi/recipes/psigem_block.json
@@ -1,0 +1,31 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "OOO",
+          "OOO",
+          "OOO"
+        ],
+        "key": {
+          "O": {
+            "item": "psi:psigem"
+          }
+        },
+        "result": {
+          "item": "psi:psigem_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psigem_block_shapeless.json
+++ b/src/generated/resources/data/psi/recipes/psigem_block_shapeless.json
@@ -1,0 +1,50 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          },
+          {
+            "item": "psi:psigem"
+          }
+        ],
+        "result": {
+          "item": "psi:psigem_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_axe.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_axe.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "GP",
+          "PI",
+          " I"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_axe"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_block.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_block.json
@@ -1,0 +1,31 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "OOO",
+          "OOO",
+          "OOO"
+        ],
+        "key": {
+          "O": {
+            "item": "psi:psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_block_shapeless.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_block_shapeless.json
@@ -1,0 +1,50 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          },
+          {
+            "item": "psi:psimetal"
+          }
+        ],
+        "result": {
+          "item": "psi:psimetal_block"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_exosuit_boots.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_exosuit_boots.json
@@ -1,0 +1,33 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "G G",
+          "P P"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_exosuit_boots"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_exosuit_chestplate.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_exosuit_chestplate.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "P P",
+          "GPG",
+          "PPP"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_exosuit_chestplate"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_exosuit_helmet.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_exosuit_helmet.json
@@ -1,0 +1,33 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "GPG",
+          "P P"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_exosuit_helmet"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_exosuit_leggings.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_exosuit_leggings.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "GPG",
+          "P P",
+          "P P"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_exosuit_leggings"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_pickaxe.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_pickaxe.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "PGP",
+          " I ",
+          " I "
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_pickaxe"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_plate_black.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_plate_black.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " C ",
+          "CIC",
+          " C "
+        ],
+        "key": {
+          "C": {
+            "tag": "minecraft:coals"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:black_psimetal_plate"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_plate_black_light.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_plate_black_light.json
@@ -1,0 +1,29 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "tag": "forge:dusts/glowstone"
+          },
+          {
+            "item": "psi:black_psimetal_plate"
+          }
+        ],
+        "result": {
+          "item": "psi:lit_black_psimetal_plate"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_plate_white.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_plate_white.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          " C ",
+          "CIC",
+          " C "
+        ],
+        "key": {
+          "C": {
+            "tag": "forge:gems/quartz"
+          },
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          }
+        },
+        "result": {
+          "item": "psi:white_psimetal_plate"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_plate_white_light.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_plate_white_light.json
@@ -1,0 +1,29 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shapeless",
+        "ingredients": [
+          {
+            "tag": "forge:dusts/glowstone"
+          },
+          {
+            "item": "psi:white_psimetal_plate"
+          }
+        ],
+        "result": {
+          "item": "psi:lit_white_psimetal_plate"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_shovel.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_shovel.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "GP",
+          " I",
+          " I"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_shovel"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/psimetal_sword.json
+++ b/src/generated/resources/data/psi/recipes/psimetal_sword.json
@@ -1,0 +1,37 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "P",
+          "G",
+          "I"
+        ],
+        "key": {
+          "P": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "G": {
+            "tag": "forge:gems/psigem"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:psimetal_sword"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_basic.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_basic.json
@@ -1,0 +1,32 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "ID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_charge.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_charge.json
@@ -1,0 +1,35 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": {
+            "tag": "forge:dusts/redstone"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet_charge"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_circle.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_circle.json
@@ -1,0 +1,40 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": [
+            {
+              "tag": "forge:slimeballs"
+            },
+            {
+              "item": "minecraft:snowball"
+            }
+          ]
+        },
+        "result": {
+          "item": "psi:spell_bullet_circle"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_grenade.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_grenade.json
@@ -1,0 +1,35 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": {
+            "tag": "forge:gunpowder"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet_grenade"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_loopcast.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_loopcast.json
@@ -1,0 +1,35 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": {
+            "tag": "forge:string"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet_loop"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_mine.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_mine.json
@@ -1,0 +1,35 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": {
+            "tag": "minecraft:buttons"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet_mine"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_bullet_projectile.json
+++ b/src/generated/resources/data/psi/recipes/spell_bullet_projectile.json
@@ -1,0 +1,35 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "AID"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/iron"
+          },
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "A": {
+            "tag": "forge:arrows"
+          }
+        },
+        "result": {
+          "item": "psi:spell_bullet_projectile"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/spell_drive.json
+++ b/src/generated/resources/data/psi/recipes/spell_drive.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "I",
+          "R",
+          "I"
+        ],
+        "key": {
+          "I": {
+            "tag": "forge:ingots/psimetal"
+          },
+          "R": {
+            "tag": "forge:dusts/redstone"
+          }
+        },
+        "result": {
+          "item": "psi:spell_drive"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/recipes/vector_ruler.json
+++ b/src/generated/resources/data/psi/recipes/vector_ruler.json
@@ -1,0 +1,34 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "type": "psi:magipsi_enabled"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "type": "minecraft:crafting_shaped",
+        "pattern": [
+          "D",
+          "I",
+          "I"
+        ],
+        "key": {
+          "D": {
+            "tag": "psi:psidust"
+          },
+          "I": {
+            "tag": "forge:ingots/iron"
+          }
+        },
+        "result": {
+          "item": "psi:vector_ruler"
+        }
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/psi/tags/items/ebony_substance.json
+++ b/src/generated/resources/data/psi/tags/items/ebony_substance.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ebony_substance"
+  ]
+}

--- a/src/generated/resources/data/psi/tags/items/ivory_substance.json
+++ b/src/generated/resources/data/psi/tags/items/ivory_substance.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:ivory_substance"
+  ]
+}

--- a/src/generated/resources/data/psi/tags/items/psidust.json
+++ b/src/generated/resources/data/psi/tags/items/psidust.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "psi:psidust"
+  ]
+}

--- a/src/main/java/vazkii/psi/common/Psi.java
+++ b/src/main/java/vazkii/psi/common/Psi.java
@@ -10,6 +10,7 @@
  */
 package vazkii.psi.common;
 
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.CrashReportExtender;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModList;
@@ -80,4 +81,8 @@ public class Psi {
 		CommandPsiUnlearn.register(event.getCommandDispatcher());
 	}
 
+	public static ResourceLocation location(String path) {
+		return new ResourceLocation(LibMisc.MOD_ID, path);
+	}
+	
 }

--- a/src/main/java/vazkii/psi/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/psi/common/crafting/ModCraftingRecipes.java
@@ -13,8 +13,10 @@ package vazkii.psi.common.crafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -29,6 +31,7 @@ import vazkii.psi.common.crafting.recipe.SensorRemoveRecipe;
 import vazkii.psi.common.item.base.ModItems;
 import vazkii.psi.common.lib.LibMisc;
 import vazkii.psi.common.lib.LibPieceNames;
+import vazkii.psi.data.MagicalPsiCondition;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = LibMisc.MOD_ID)
 public class ModCraftingRecipes {
@@ -43,6 +46,8 @@ public class ModCraftingRecipes {
 			name(SensorAttachRecipe.SERIALIZER, "sensor_attach"),
 			name(SensorRemoveRecipe.SERIALIZER, "sensor_remove")
 		);
+
+		CraftingHelper.register(MagicalPsiCondition.Serializer.INSTANCE);
 	}
 
 	private static <T extends IForgeRegistryEntry<? extends T>> T name(T entry, String name) {
@@ -56,9 +61,9 @@ public class ModCraftingRecipes {
 				new ItemStack(ModItems.psimetal),
 				new ItemStack(ModItems.cadAssemblyIron));
 		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_GREATER_INFUSION, Ingredient.fromTag(Tags.Items.GEMS_DIAMOND),
-				new ItemStack(ModItems.psimetal),
+				new ItemStack(ModItems.psigem),
 				new ItemStack(ModItems.cadAssemblyPsimetal));
-		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY, Ingredient.fromTag(Tags.Items.ORES_COAL),
+		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY, Ingredient.fromTag(ItemTags.COALS),
 				new ItemStack(ModItems.ebonySubstance),
 				new ItemStack(ModItems.cadAssemblyPsimetal));
 		PsiAPI.registerTrickRecipe(LibPieceNames.TRICK_EBONY_IVORY, Ingredient.fromTag(Tags.Items.GEMS_QUARTZ),

--- a/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalAxe.java
+++ b/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalAxe.java
@@ -28,6 +28,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ToolType;
+import vazkii.arl.util.RegistryHelper;
 import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.cad.ISocketable;
 import vazkii.psi.api.internal.TooltipHelper;
@@ -42,6 +43,7 @@ public class ItemPsimetalAxe extends AxeItem implements IPsimetalTool {
 
     public ItemPsimetalAxe(String name, Item.Properties properties) {
         super(PsiAPI.PSIMETAL_TOOL_MATERIAL, 5.0F, -3.0F, properties.addToolType(ToolType.AXE, PsiAPI.PSIMETAL_TOOL_MATERIAL.getHarvestLevel()));
+		RegistryHelper.registerItem(this, name);
     }
 
     @Override

--- a/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalSword.java
+++ b/src/main/java/vazkii/psi/common/item/tool/ItemPsimetalSword.java
@@ -27,6 +27,7 @@ import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import vazkii.arl.util.RegistryHelper;
 import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.cad.ISocketable;
 import vazkii.psi.api.internal.TooltipHelper;
@@ -45,6 +46,7 @@ public class ItemPsimetalSword extends SwordItem implements IPsimetalTool {
 
     public ItemPsimetalSword(String name, Item.Properties properties) {
         super(PsiAPI.PSIMETAL_TOOL_MATERIAL, 3, -2.4F, properties);
+		RegistryHelper.registerItem(this, name);
     }
 
     @Override

--- a/src/main/java/vazkii/psi/common/lib/ModTags.java
+++ b/src/main/java/vazkii/psi/common/lib/ModTags.java
@@ -1,19 +1,29 @@
 package vazkii.psi.common.lib;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.Item;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.Tag;
 import net.minecraft.util.ResourceLocation;
 
 public class ModTags {
 
-    public static final Tag<Item> DUST_PSI = forgeTag("dusts/psi");
-    public static final Tag<Item> INGOT_PSI = forgeTag("ingots/psi");
-    public static final Tag<Item> GEM_PSI = forgeTag("gems/psi");
-    public static final Tag<Item> INGOT_EBONY_PSI = forgeTag("ingots/ebony_psi");
-    public static final Tag<Item> INGOT_IVORY_PSI = forgeTag("ingots/ivory_psi");
-    public static final Tag<Item> SUBSTANCE_IVORY = forgeTag("dusts/ivory_substance");
-    public static final Tag<Item> SUBSTANCE_EBONY = forgeTag("dusts/ebony_susbtance");
+    public static final Tag<Item> PSIDUST = tag("psidust");
+    public static final Tag<Item> IVORY_SUBSTANCE = tag("ivory_substance");
+    public static final Tag<Item> EBONY_SUBSTANCE = tag("ebony_substance");
+    
+    public static final Tag<Item> INGOT_PSIMETAL = forgeTag("ingots/psimetal");
+    public static final Tag<Item> BLOCK_PSIMETAL = forgeTag("storage_blocks/psimetal");
+
+    public static final Tag<Item> GEM_PSIGEM = forgeTag("gems/psigem");
+    public static final Tag<Item> BLOCK_PSIGEM = forgeTag("storage_blocks/psigem");
+
+    public static final Tag<Item> INGOT_EBONY_PSIMETAL = forgeTag("ingots/ebony_psimetal");
+    public static final Tag<Item> BLOCK_EBONY_PSIMETAL = forgeTag("storage_blocks/ebony_psimetal");
+    
+    public static final Tag<Item> INGOT_IVORY_PSIMETAL = forgeTag("ingots/ivory_psimetal");
+    public static final Tag<Item> BLOCK_IVORY_PSIMETAL = forgeTag("storage_blocks/ivory_psimetal");
 
     private static Tag<Item> tag(String name) {
         return new ItemTags.Wrapper(new ResourceLocation(LibMisc.MOD_ID, name));
@@ -21,5 +31,16 @@ public class ModTags {
 
     private static Tag<Item> forgeTag(String name) {
         return new ItemTags.Wrapper(new ResourceLocation("forge", name));
+    }
+    
+    public static class Blocks {
+        public static final Tag<Block> BLOCK_PSIMETAL = fromTag(ModTags.BLOCK_PSIMETAL);
+        public static final Tag<Block> BLOCK_PSIGEM = fromTag(ModTags.BLOCK_PSIGEM);
+        public static final Tag<Block> BLOCK_EBONY_PSIMETAL = fromTag(ModTags.BLOCK_EBONY_PSIMETAL);
+        public static final Tag<Block> BLOCK_IVORY_PSIMETAL = fromTag(ModTags.BLOCK_IVORY_PSIMETAL);
+
+        private static Tag<Block> fromTag(Tag<?> tag) {
+            return new BlockTags.Wrapper(tag.getId());
+        }
     }
 }

--- a/src/main/java/vazkii/psi/data/BlockTagProvider.java
+++ b/src/main/java/vazkii/psi/data/BlockTagProvider.java
@@ -1,0 +1,25 @@
+package vazkii.psi.data;
+
+import net.minecraft.data.BlockTagsProvider;
+import net.minecraft.data.DataGenerator;
+import vazkii.psi.common.block.base.ModBlocks;
+import vazkii.psi.common.lib.ModTags;
+
+public class BlockTagProvider extends BlockTagsProvider {
+	public BlockTagProvider(DataGenerator generator) {
+		super(generator);
+	}
+
+	@Override
+	protected void registerTags() {
+		getBuilder(ModTags.Blocks.BLOCK_PSIMETAL).add(ModBlocks.psimetalBlock);
+		getBuilder(ModTags.Blocks.BLOCK_PSIGEM).add(ModBlocks.psigemBlock);
+		getBuilder(ModTags.Blocks.BLOCK_EBONY_PSIMETAL).add(ModBlocks.psimetalEbony);
+		getBuilder(ModTags.Blocks.BLOCK_IVORY_PSIMETAL).add(ModBlocks.psimetalIvory);
+	}
+
+	@Override
+	public String getName() {
+		return "Psi block tags";
+	}
+}

--- a/src/main/java/vazkii/psi/data/DataGenerator.java
+++ b/src/main/java/vazkii/psi/data/DataGenerator.java
@@ -1,8 +1,5 @@
 package vazkii.psi.data;
 
-import net.minecraft.item.crafting.IRecipeSerializer;
-import net.minecraftforge.common.crafting.CraftingHelper;
-import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
@@ -13,12 +10,8 @@ public class DataGenerator {
 
     @SubscribeEvent
     public static void gatherData(GatherDataEvent event) {
-        event.getGenerator().addProvider(new RecipeGenerator(event.getGenerator()));
+        event.getGenerator().addProvider(new BlockTagProvider(event.getGenerator()));
         event.getGenerator().addProvider(new ItemTagProvider(event.getGenerator()));
-    }
-
-    @SubscribeEvent
-    public static void registerRecipeSerializers(RegistryEvent.Register<IRecipeSerializer<?>> event) {
-        CraftingHelper.register(MagicalPsiCondition.Serializer.INSTANCE);
+        event.getGenerator().addProvider(new RecipeGenerator(event.getGenerator()));
     }
 }

--- a/src/main/java/vazkii/psi/data/ItemTagProvider.java
+++ b/src/main/java/vazkii/psi/data/ItemTagProvider.java
@@ -6,20 +6,26 @@ import vazkii.psi.common.item.base.ModItems;
 import vazkii.psi.common.lib.ModTags;
 
 public class ItemTagProvider extends ItemTagsProvider {
-    public ItemTagProvider(DataGenerator p_i48255_1_) {
-        super(p_i48255_1_);
+    public ItemTagProvider(DataGenerator generator) {
+        super(generator);
     }
 
     @Override
     protected void registerTags() {
-        getBuilder(ModTags.DUST_PSI).add(ModItems.psidust);
-        getBuilder(ModTags.INGOT_PSI).add(ModItems.psimetal);
-        getBuilder(ModTags.GEM_PSI).add(ModItems.psigem);
-        getBuilder(ModTags.INGOT_EBONY_PSI).add(ModItems.ebonyPsimetal);
-        getBuilder(ModTags.INGOT_IVORY_PSI).add(ModItems.ivoryPsimetal);
-        getBuilder(ModTags.SUBSTANCE_EBONY).add(ModItems.ebonySubstance);
-        getBuilder(ModTags.SUBSTANCE_IVORY).add(ModItems.ivorySubstance);
-
+        getBuilder(ModTags.PSIDUST).add(ModItems.psidust);
+        getBuilder(ModTags.EBONY_SUBSTANCE).add(ModItems.ebonySubstance);
+        getBuilder(ModTags.IVORY_SUBSTANCE).add(ModItems.ivorySubstance);
+        
+        getBuilder(ModTags.INGOT_PSIMETAL).add(ModItems.psimetal);
+        copy(ModTags.Blocks.BLOCK_PSIMETAL, ModTags.BLOCK_PSIMETAL);
+        
+        getBuilder(ModTags.GEM_PSIGEM).add(ModItems.psigem);
+        copy(ModTags.Blocks.BLOCK_PSIGEM, ModTags.BLOCK_PSIGEM);
+        
+        getBuilder(ModTags.INGOT_EBONY_PSIMETAL).add(ModItems.ebonyPsimetal);
+        copy(ModTags.Blocks.BLOCK_EBONY_PSIMETAL, ModTags.BLOCK_EBONY_PSIMETAL);
+        getBuilder(ModTags.INGOT_IVORY_PSIMETAL).add(ModItems.ivoryPsimetal);
+        copy(ModTags.Blocks.BLOCK_IVORY_PSIMETAL, ModTags.BLOCK_IVORY_PSIMETAL);
     }
 
     @Override

--- a/src/main/java/vazkii/psi/data/MagicalPsiCondition.java
+++ b/src/main/java/vazkii/psi/data/MagicalPsiCondition.java
@@ -9,7 +9,7 @@ import vazkii.psi.common.lib.LibMisc;
 
 public class MagicalPsiCondition implements ICondition {
     public static final MagicalPsiCondition INSTANCE = new MagicalPsiCondition();
-    public static final ResourceLocation NAME = new ResourceLocation(LibMisc.MOD_ID, "magipsi_loaded");
+    public static final ResourceLocation NAME = new ResourceLocation(LibMisc.MOD_ID, "magipsi_enabled");
 
     @Override
     public ResourceLocation getID() {
@@ -27,7 +27,7 @@ public class MagicalPsiCondition implements ICondition {
 
     @Override
     public String toString() {
-        return "magipsi_loaded";
+        return "magipsi_enabled";
     }
 
     public static class Serializer implements IConditionSerializer<MagicalPsiCondition> {

--- a/src/main/java/vazkii/psi/data/RecipeGenerator.java
+++ b/src/main/java/vazkii/psi/data/RecipeGenerator.java
@@ -1,828 +1,738 @@
 package vazkii.psi.data;
 
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.ICriterionInstance;
+import net.minecraft.advancements.IRequirementsStrategy;
+import net.minecraft.advancements.criterion.RecipeUnlockedTrigger;
+import net.minecraft.data.CustomRecipeBuilder;
 import net.minecraft.data.DataGenerator;
-import net.minecraft.data.*;
+import net.minecraft.data.IFinishedRecipe;
+import net.minecraft.data.RecipeProvider;
+import net.minecraft.data.ShapedRecipeBuilder;
+import net.minecraft.data.ShapelessRecipeBuilder;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.SpecialRecipeSerializer;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.crafting.ConditionalAdvancement;
 import net.minecraftforge.common.crafting.ConditionalRecipe;
 import net.minecraftforge.common.crafting.conditions.IConditionBuilder;
-import net.minecraftforge.common.data.ForgeRecipeProvider;
+import net.minecraftforge.common.crafting.conditions.NotCondition;
+import vazkii.psi.common.Psi;
 import vazkii.psi.common.block.base.ModBlocks;
-import vazkii.psi.common.crafting.recipe.*;
+import vazkii.psi.common.crafting.recipe.AssemblyScavengeRecipe;
+import vazkii.psi.common.crafting.recipe.BulletToDriveRecipe;
+import vazkii.psi.common.crafting.recipe.ColorizerChangeRecipe;
+import vazkii.psi.common.crafting.recipe.DriveDuplicateRecipe;
+import vazkii.psi.common.crafting.recipe.SensorAttachRecipe;
+import vazkii.psi.common.crafting.recipe.SensorRemoveRecipe;
 import vazkii.psi.common.item.base.ModItems;
-import vazkii.psi.common.lib.LibMisc;
 import vazkii.psi.common.lib.ModTags;
 
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
-public class RecipeGenerator extends ForgeRecipeProvider implements IConditionBuilder {
+public class RecipeGenerator extends RecipeProvider implements IConditionBuilder {
 
-    public RecipeGenerator(DataGenerator generator) {
-        super(generator);
-    }
+	public RecipeGenerator(DataGenerator generator) {
+		super(generator);
+	}
 
-    @Override
-    protected void registerRecipes(Consumer<IFinishedRecipe> consumer) {
-        specialRecipe(AssemblyScavengeRecipe.SERIALIZER, consumer);
-        specialRecipe(BulletToDriveRecipe.SERIALIZER, consumer);
-        specialRecipe(ColorizerChangeRecipe.SERIALIZER, consumer);
-        specialRecipe(DriveDuplicateRecipe.SERIALIZER, consumer);
-        specialRecipe(SensorAttachRecipe.SERIALIZER, consumer);
-        specialRecipe(SensorRemoveRecipe.SERIALIZER, consumer);
+	@Override
+	protected void registerRecipes(Consumer<IFinishedRecipe> consumer) {
+		specialRecipe(AssemblyScavengeRecipe.SERIALIZER, consumer);
+		specialRecipe(BulletToDriveRecipe.SERIALIZER, consumer);
+		specialRecipe(ColorizerChangeRecipe.SERIALIZER, consumer);
+		specialRecipe(DriveDuplicateRecipe.SERIALIZER, consumer);
+		specialRecipe(SensorAttachRecipe.SERIALIZER, consumer);
+		specialRecipe(SensorRemoveRecipe.SERIALIZER, consumer);
 
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.cadAssembler)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('P', Items.PISTON)
-                        .patternLine("IPI")
-                        .patternLine("I I")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "assembler"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.programmer)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.DUST_PSI)
-                        .patternLine("IDI")
-                        .patternLine("I I")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "programmer"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.ebonyPsimetal)
-                        .key('S', ModTags.SUBSTANCE_EBONY)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine("SSS")
-                        .patternLine("SIS")
-                        .patternLine("SSS")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ebony_psimetal"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.ivoryPsimetal)
-                        .key('S', ModTags.SUBSTANCE_IVORY)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine("SSS")
-                        .patternLine("SIS")
-                        .patternLine("SSS")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ivory_psimetal"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyIron)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("III")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_assembly_iron"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyGold)
-                        .key('I', Tags.Items.INGOTS_GOLD)
-                        .patternLine("III")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_assembly_gold"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyPsimetal)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine("III")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_assembly_psimetal"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyEbony)
-                        .key('I', ModTags.INGOT_EBONY_PSI)
-                        .patternLine("III")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_assembly_ebony"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyIvory)
-                        .key('I', ModTags.INGOT_IVORY_PSI)
-                        .patternLine("III")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_assembly_ivory"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreBasic)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.DUST_PSI)
-                        .patternLine(" I ")
-                        .patternLine("IDI")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_core_basic"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreOverclocked)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_REDSTONE)
-                        .patternLine(" I ")
-                        .patternLine("IDI")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_core_overclocked"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreConductive)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_GLOWSTONE)
-                        .patternLine(" I ")
-                        .patternLine("IDI")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_core_conductive"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreHyperClocked)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_REDSTONE)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine(" G ")
-                        .patternLine("IDI")
-                        .patternLine(" G ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_core_hyperclocked"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreRadiative)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_GLOWSTONE)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine(" G ")
-                        .patternLine("IDI")
-                        .patternLine(" G ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_core_radiative"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketBasic)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.DUST_PSI)
-                        .patternLine("DI ")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_socket_basic"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketSignaling)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_REDSTONE)
-                        .patternLine("DI ")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_socket_signaling"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketLarge)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_GLOWSTONE)
-                        .patternLine("DI ")
-                        .patternLine("I  ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_socket_large"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketTransmissive)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_REDSTONE)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("DI ")
-                        .patternLine("IG ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_socket_transmissive"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketHuge)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('D', Tags.Items.DUSTS_GLOWSTONE)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("DI ")
-                        .patternLine("IG ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_socket_huge"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryBasic)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.DUST_PSI)
-                        .key('G', Tags.Items.INGOTS_GOLD)
-                        .patternLine("I")
-                        .patternLine("D")
-                        .patternLine("G")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_battery_basic"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryExtended)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.INGOT_PSI)
-                        .key('G', Tags.Items.INGOTS_GOLD)
-                        .patternLine("I")
-                        .patternLine("D")
-                        .patternLine("G")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_battery_extended"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryUltradense)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', ModTags.GEM_PSI)
-                        .key('G', Tags.Items.INGOTS_GOLD)
-                        .patternLine("I")
-                        .patternLine("D")
-                        .patternLine("G")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_battery_ultradense"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerWhite)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_WHITE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_white"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerOrange)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_ORANGE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_orange"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerMagenta)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_MAGENTA)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_magenta"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLightBlue)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_LIGHT_BLUE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_light_blue"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerYellow)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_YELLOW)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_yellow"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLime)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_LIME)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_lime"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPink)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_PINK)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_pink"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerGray)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_GRAY)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_gray"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLightGray)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_LIGHT_GRAY)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_light_gray"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerCyan)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_CYAN)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_cyan"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPurple)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_PURPLE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_purple"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBlue)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_BLUE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_blue"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBrown)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_BROWN)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_brown"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerGreen)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_GREEN)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_green"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerRed)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_RED)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_red"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBlack)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.DYES_BLACK)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_black"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerRainbow)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', Tags.Items.GEMS_PRISMARINE)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_rainbow"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPsi)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('G', Tags.Items.GLASS)
-                        .key('C', ModTags.DUST_PSI)
-                        .patternLine(" D ")
-                        .patternLine("GCG")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "cad_colorizer_psi"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.spellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .patternLine("ID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_basic"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.projectileSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.ARROWS)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_projectile"));
+		ICriterionInstance hasIron = hasItem(Tags.Items.INGOTS_IRON);
+		ICriterionInstance hasPsimetal = hasItem(ModTags.INGOT_PSIMETAL);
+		ICriterionInstance hasEbonyPsimetal = hasItem(ModTags.INGOT_EBONY_PSIMETAL);
+		ICriterionInstance hasIvoryPsimetal = hasItem(ModTags.INGOT_IVORY_PSIMETAL);
+		ICriterionInstance hasPsidust = hasItem(ModTags.PSIDUST);
 
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.loopSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.STRING)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_loopcast"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.circleSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.SLIMEBALLS)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_circle"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.projectileSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.ARROWS)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_projectile"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.circleSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Items.SNOWBALL)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_circle"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.grenadeSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.GUNPOWDER)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_grenade"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.chargeSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.DUSTS_REDSTONE)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_charge"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.mineSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', ItemTags.BUTTONS)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_mine"));
+		// TODO: Pull Magical Psi recipes into here? Conditional recipes can hold more than one recipe, and 
+		//  only the first one matching its condition will be enabled, so it makes sense to have both in one json.
 
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.chargeSpellBullet)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .key('D', Tags.Items.GLASS)
-                        .key('A', Tags.Items.DUSTS_REDSTONE)
-                        .patternLine("AID")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_bullet_charge"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.spellDrive)
-                        .key('I', ModTags.INGOT_PSI)
-                        .key('R', Tags.Items.DUSTS_REDSTONE)
-                        .patternLine("I")
-                        .patternLine("R")
-                        .patternLine("I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "spell_drive"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalShovel)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("GP")
-                        .patternLine(" I")
-                        .patternLine(" I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_shovel"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalPickaxe)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("PGP")
-                        .patternLine(" I ")
-                        .patternLine(" I ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_pickaxe"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalAxe)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("GP")
-                        .patternLine("PI")
-                        .patternLine(" I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_axe"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalSword)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("P")
-                        .patternLine("G")
-                        .patternLine("I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_sword"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitHelmet)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("GPG")
-                        .patternLine("P P")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_exosuit_helmet"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitChestplate)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("P P")
-                        .patternLine("GPG")
-                        .patternLine("PPP")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_exosuit_chestplate"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitLeggings)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("GPG")
-                        .patternLine("P P")
-                        .patternLine("P P")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_exosuit_leggings"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitBoots)
-                        .key('P', ModTags.INGOT_PSI)
-                        .key('G', ModTags.GEM_PSI)
-                        .patternLine("G G")
-                        .patternLine("P P")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_exosuit_boots"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.detonator)
-                        .key('P', ModTags.DUST_PSI)
-                        .key('B', ItemTags.BUTTONS)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine(" B ")
-                        .patternLine("IPI")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "detonator"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitController)
-                        .key('R', Tags.Items.DUSTS_REDSTONE)
-                        .key('G', Tags.Items.GLASS)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine("R")
-                        .patternLine("G")
-                        .patternLine("I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "exosuit_controller"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.vectorRuler)
-                        .key('D', ModTags.DUST_PSI)
-                        .key('I', Tags.Items.INGOTS_IRON)
-                        .patternLine("D")
-                        .patternLine("I")
-                        .patternLine("I")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "vector_ruler"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorLight)
-                        .key('M', Tags.Items.DUSTS_GLOWSTONE)
-                        .key('R', Tags.Items.INGOTS_IRON)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" I ")
-                        .patternLine("IMR")
-                        .patternLine(" R ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "exosuit_sensor_light"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorWater)
-                        .key('M', Tags.Items.GEMS_PRISMARINE)
-                        .key('R', Tags.Items.INGOTS_IRON)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" I ")
-                        .patternLine("IMR")
-                        .patternLine(" R ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "exosuit_sensor_water"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorHeat)
-                        .key('M', Items.FIRE_CHARGE)
-                        .key('R', Tags.Items.INGOTS_IRON)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" I ")
-                        .patternLine("IMR")
-                        .patternLine(" R ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "exosuit_sensor_heat"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorStress)
-                        .key('M', Items.GLISTERING_MELON_SLICE)
-                        .key('R', Tags.Items.INGOTS_IRON)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" I ")
-                        .patternLine("IMR")
-                        .patternLine(" R ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "exosuit_sensor_stress"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psidustBlock.asItem())
-                        .key('O', ModItems.psidust)
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psidust_block"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalBlock.asItem())
-                        .key('O', ModItems.psimetal)
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_block"));
+		buildMagicalWrapper(Psi.location("assembler"), consumer,
+				hasIron, "has_iron", ShapedRecipeBuilder.shapedRecipe(ModBlocks.cadAssembler)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('P', Items.PISTON)
+						.patternLine("IPI")
+						.patternLine("I I")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("programmer"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModBlocks.programmer)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.patternLine("IDI")
+						.patternLine("I I")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("ebony_psimetal"), consumer,
+				hasItem(ModItems.ebonySubstance), "has_ebony_substance", ShapedRecipeBuilder.shapedRecipe(ModItems.ebonyPsimetal)
+						.key('S', ModTags.EBONY_SUBSTANCE)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine("SSS")
+						.patternLine("SIS")
+						.patternLine("SSS")
+		);
+		buildMagicalWrapper(Psi.location("ivory_psimetal"), consumer,
+				hasItem(ModItems.ivorySubstance), "has_ivory_substance", ShapedRecipeBuilder.shapedRecipe(ModItems.ivoryPsimetal)
+						.key('S', ModTags.IVORY_SUBSTANCE)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine("SSS")
+						.patternLine("SIS")
+						.patternLine("SSS")
+		);
+		buildMagicalWrapper(Psi.location("cad_assembly_iron"), consumer,
+				hasIron, "has_iron", ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyIron)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("III")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_assembly_gold"), consumer,
+				hasItem(Tags.Items.INGOTS_GOLD), "has_gold", ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyGold)
+						.key('I', Tags.Items.INGOTS_GOLD)
+						.patternLine("III")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_assembly_psimetal"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyPsimetal)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine("III")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_assembly_ebony"), consumer,
+				hasEbonyPsimetal, "has_ebony_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyEbony)
+						.key('I', ModTags.INGOT_EBONY_PSIMETAL)
+						.patternLine("III")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_assembly_ivory"), consumer,
+				hasIvoryPsimetal, "has_ivory_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadAssemblyIvory)
+						.key('I', ModTags.INGOT_IVORY_PSIMETAL)
+						.patternLine("III")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_core_basic"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreBasic)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.patternLine(" I ")
+						.patternLine("IDI")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_core_overclocked"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreOverclocked)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_REDSTONE)
+						.patternLine(" I ")
+						.patternLine("IDI")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_core_conductive"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreConductive)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_GLOWSTONE)
+						.patternLine(" I ")
+						.patternLine("IDI")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_core_hyperclocked"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreHyperClocked)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_REDSTONE)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine(" G ")
+						.patternLine("IDI")
+						.patternLine(" G ")
+		);
+		buildMagicalWrapper(Psi.location("cad_core_radiative"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadCoreRadiative)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_GLOWSTONE)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine(" G ")
+						.patternLine("IDI")
+						.patternLine(" G ")
+		);
+		buildMagicalWrapper(Psi.location("cad_socket_basic"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketBasic)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.patternLine("DI ")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_socket_signaling"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketSignaling)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_REDSTONE)
+						.patternLine("DI ")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_socket_large"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketLarge)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_GLOWSTONE)
+						.patternLine("DI ")
+						.patternLine("I  ")
+		);
+		buildMagicalWrapper(Psi.location("cad_socket_transmissive"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketTransmissive)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_REDSTONE)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("DI ")
+						.patternLine("IG ")
+		);
+		buildMagicalWrapper(Psi.location("cad_socket_huge"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadSocketHuge)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('D', Tags.Items.DUSTS_GLOWSTONE)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("DI ")
+						.patternLine("IG ")
+		);
+		buildMagicalWrapper(Psi.location("cad_battery_basic"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryBasic)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('G', Tags.Items.INGOTS_GOLD)
+						.patternLine("I")
+						.patternLine("D")
+						.patternLine("G")
+		);
+		buildMagicalWrapper(Psi.location("cad_battery_extended"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryExtended)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.INGOT_PSIMETAL)
+						.key('G', Tags.Items.INGOTS_GOLD)
+						.patternLine("I")
+						.patternLine("D")
+						.patternLine("G")
+		);
+		buildMagicalWrapper(Psi.location("cad_battery_ultradense"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.cadBatteryUltradense)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.GEM_PSIGEM)
+						.key('G', Tags.Items.INGOTS_GOLD)
+						.patternLine("I")
+						.patternLine("D")
+						.patternLine("G")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_white"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerWhite)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_WHITE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_orange"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerOrange)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_ORANGE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_magenta"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerMagenta)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_MAGENTA)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_light_blue"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLightBlue)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_LIGHT_BLUE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_yellow"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerYellow)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_YELLOW)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_lime"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLime)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_LIME)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_pink"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPink)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_PINK)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_gray"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerGray)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_GRAY)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_light_gray"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerLightGray)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_LIGHT_GRAY)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_cyan"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerCyan)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_CYAN)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_purple"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPurple)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_PURPLE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_blue"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBlue)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_BLUE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_brown"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBrown)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_BROWN)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_green"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerGreen)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_GREEN)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_red"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerRed)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_RED)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_black"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerBlack)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.DYES_BLACK)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_rainbow"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerRainbow)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', Tags.Items.GEMS_PRISMARINE)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("cad_colorizer_psi"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.cadColorizerPsi)
+						.setGroup("psi:colorizer")
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('G', Tags.Items.GLASS)
+						.key('C', ModTags.PSIDUST)
+						.patternLine(" D ")
+						.patternLine("GCG")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_basic"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.spellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.patternLine("ID")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_projectile"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.projectileSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', Tags.Items.ARROWS)
+						.patternLine("AID")
+		);
 
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psigemBlock.asItem())
-                        .key('O', ModItems.psigem)
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psigem_block"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalEbony.asItem())
-                        .key('O', ModItems.ebonyPsimetal)
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ebony_block"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalIvory.asItem())
-                        .key('O', ModItems.ivoryPsimetal)
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        .patternLine("OOO")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ivory_block"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psidustBlock.asItem())
-                        .addIngredient(ModItems.psidust, 9)
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psidust_block_shapeless"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalBlock.asItem())
-                        .addIngredient(ModItems.psimetal, 9)
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_block_shapeless"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psigemBlock.asItem())
-                        .addIngredient(ModItems.psigem, 9)
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psigem_block_shapeless"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalEbony.asItem())
-                        .addIngredient(ModItems.ebonyPsimetal, 9)
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ebony_block_shapeless"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalIvory.asItem())
-                        .addIngredient(ModItems.ivoryPsimetal, 9)
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "ivory_block_shapeless"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalPlateBlack.asItem())
-                        .key('O', Tags.Items.ORES_COAL)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" C ")
-                        .patternLine("CIC")
-                        .patternLine(" C ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_plate_black"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalPlateWhite.asItem())
-                        .key('O', Tags.Items.GEMS_QUARTZ)
-                        .key('I', ModTags.INGOT_PSI)
-                        .patternLine(" C ")
-                        .patternLine("CIC")
-                        .patternLine(" C ")
-                        ::build).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_plate_white"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalPlateBlackLight.asItem())
-                        .addIngredient(Tags.Items.DUSTS_GLOWSTONE)
-                        .addIngredient(ModBlocks.psimetalPlateBlack.asItem())
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_plate_black_light"));
-        ConditionalRecipe.builder()
-                .addCondition(
-                        MagicalPsiCondition.INSTANCE)
-                .addRecipe(ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalPlateWhiteLight.asItem())
-                        .addIngredient(Tags.Items.DUSTS_GLOWSTONE)
-                        .addIngredient(ModBlocks.psimetalPlateWhite.asItem())
-                        ::build
-                ).build(consumer, new ResourceLocation(LibMisc.MOD_ID, "psimetal_plate_white_light"));
+		buildMagicalWrapper(Psi.location("spell_bullet_loopcast"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.loopSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', Tags.Items.STRING)
+						.patternLine("AID")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_circle"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.circleSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', Ingredient.fromItemListStream(Stream.of(
+								new Ingredient.TagList(Tags.Items.SLIMEBALLS),
+								new Ingredient.SingleItemList(new ItemStack(Items.SNOWBALL)))))
+						.patternLine("AID")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_grenade"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.grenadeSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', Tags.Items.GUNPOWDER)
+						.patternLine("AID")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_charge"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.chargeSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', Tags.Items.DUSTS_REDSTONE)
+						.patternLine("AID")
+		);
+		buildMagicalWrapper(Psi.location("spell_bullet_mine"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.mineSpellBullet)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.key('D', ModTags.PSIDUST)
+						.key('A', ItemTags.BUTTONS)
+						.patternLine("AID")
+		);
 
-    }
+		buildMagicalWrapper(Psi.location("spell_drive"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.spellDrive)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.key('R', Tags.Items.DUSTS_REDSTONE)
+						.patternLine("I")
+						.patternLine("R")
+						.patternLine("I")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_shovel"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalShovel)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("GP")
+						.patternLine(" I")
+						.patternLine(" I")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_pickaxe"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalPickaxe)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("PGP")
+						.patternLine(" I ")
+						.patternLine(" I ")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_axe"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalAxe)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("GP")
+						.patternLine("PI")
+						.patternLine(" I")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_sword"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalSword)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("P")
+						.patternLine("G")
+						.patternLine("I")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_exosuit_helmet"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitHelmet)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("GPG")
+						.patternLine("P P")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_exosuit_chestplate"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitChestplate)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("P P")
+						.patternLine("GPG")
+						.patternLine("PPP")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_exosuit_leggings"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitLeggings)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("GPG")
+						.patternLine("P P")
+						.patternLine("P P")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_exosuit_boots"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.psimetalExosuitBoots)
+						.key('P', ModTags.INGOT_PSIMETAL)
+						.key('G', ModTags.GEM_PSIGEM)
+						.patternLine("G G")
+						.patternLine("P P")
+		);
+		buildMagicalWrapper(Psi.location("detonator"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.detonator)
+						.key('P', ModTags.PSIDUST)
+						.key('B', ItemTags.BUTTONS)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine(" B ")
+						.patternLine("IPI")
+		);
+		buildMagicalWrapper(Psi.location("exosuit_controller"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitController)
+						.key('R', Tags.Items.DUSTS_REDSTONE)
+						.key('G', Tags.Items.GLASS)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine("R")
+						.patternLine("G")
+						.patternLine("I")
+		);
+		buildMagicalWrapper(Psi.location("vector_ruler"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModItems.vectorRuler)
+						.key('D', ModTags.PSIDUST)
+						.key('I', Tags.Items.INGOTS_IRON)
+						.patternLine("D")
+						.patternLine("I")
+						.patternLine("I")
+		);
+		buildMagicalWrapper(Psi.location("exosuit_sensor_light"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorLight)
+						.key('M', Tags.Items.DUSTS_GLOWSTONE)
+						.key('R', Tags.Items.INGOTS_IRON)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" I ")
+						.patternLine("IMR")
+						.patternLine(" R ")
+		);
+		buildMagicalWrapper(Psi.location("exosuit_sensor_water"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorWater)
+						.key('M', Tags.Items.GEMS_PRISMARINE)
+						.key('R', Tags.Items.INGOTS_IRON)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" I ")
+						.patternLine("IMR")
+						.patternLine(" R ")
+		);
+		buildMagicalWrapper(Psi.location("exosuit_sensor_heat"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorHeat)
+						.key('M', Items.FIRE_CHARGE)
+						.key('R', Tags.Items.INGOTS_IRON)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" I ")
+						.patternLine("IMR")
+						.patternLine(" R ")
+		);
+		buildMagicalWrapper(Psi.location("exosuit_sensor_stress"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModItems.exosuitSensorStress)
+						.key('M', Items.GLISTERING_MELON_SLICE)
+						.key('R', Tags.Items.INGOTS_IRON)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" I ")
+						.patternLine("IMR")
+						.patternLine(" R ")
+		);
+		buildMagicalWrapper(Psi.location("psidust_block"), consumer,
+				hasPsidust, "has_psidust", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psidustBlock.asItem())
+						.key('O', ModItems.psidust)
+						.patternLine("OOO")
+						.patternLine("OOO")
+						.patternLine("OOO")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_block"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalBlock.asItem())
+						.key('O', ModItems.psimetal)
+						.patternLine("OOO")
+						.patternLine("OOO")
+						.patternLine("OOO")
+		);
+		buildMagicalWrapper(Psi.location("psigem_block"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psigemBlock.asItem())
+						.key('O', ModItems.psigem)
+						.patternLine("OOO")
+						.patternLine("OOO")
+						.patternLine("OOO")
+		);
+		buildMagicalWrapper(Psi.location("ebony_block"), consumer,
+				hasEbonyPsimetal, "has_ebony_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalEbony.asItem())
+						.key('O', ModItems.ebonyPsimetal)
+						.patternLine("OOO")
+						.patternLine("OOO")
+						.patternLine("OOO")
+		);
+		buildMagicalWrapper(Psi.location("ivory_block"), consumer,
+				hasIvoryPsimetal, "has_ivory_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalIvory.asItem())
+						.key('O', ModItems.ivoryPsimetal)
+						.patternLine("OOO")
+						.patternLine("OOO")
+						.patternLine("OOO")
+		);
+		buildMagicalWrapper(Psi.location("psidust_block_shapeless"), consumer,
+				hasPsidust, "has_psidust",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psidustBlock.asItem())
+						.addIngredient(ModItems.psidust, 9)
+		);
+		buildMagicalWrapper(Psi.location("psimetal_block_shapeless"), consumer,
+				hasPsimetal, "has_psimetal",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalBlock.asItem())
+						.addIngredient(ModItems.psimetal, 9)
+		);
+		buildMagicalWrapper(Psi.location("psigem_block_shapeless"), consumer,
+				hasItem(ModItems.psigem), "has_psigem",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psigemBlock.asItem())
+						.addIngredient(ModItems.psigem, 9)
+		);
+		buildMagicalWrapper(Psi.location("ebony_block_shapeless"), consumer,
+				hasEbonyPsimetal, "has_ebony_psimetal",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalEbony.asItem())
+						.addIngredient(ModItems.ebonyPsimetal, 9)
+		);
+		buildMagicalWrapper(Psi.location("ivory_block_shapeless"), consumer,
+				hasIvoryPsimetal, "has_ivory_psimetal",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalIvory.asItem())
+						.addIngredient(ModItems.ivoryPsimetal, 9)
+		);
+		buildMagicalWrapper(Psi.location("psimetal_plate_black"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalPlateBlack.asItem())
+						.key('C', ItemTags.COALS)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" C ")
+						.patternLine("CIC")
+						.patternLine(" C ")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_plate_white"), consumer,
+				hasPsimetal, "has_psimetal", ShapedRecipeBuilder.shapedRecipe(ModBlocks.psimetalPlateWhite.asItem())
+						.key('C', Tags.Items.GEMS_QUARTZ)
+						.key('I', ModTags.INGOT_PSIMETAL)
+						.patternLine(" C ")
+						.patternLine("CIC")
+						.patternLine(" C ")
+		);
+		buildMagicalWrapper(Psi.location("psimetal_plate_black_light"), consumer,
+				hasPsimetal, "has_psimetal",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalPlateBlackLight.asItem())
+						.addIngredient(Tags.Items.DUSTS_GLOWSTONE)
+						.addIngredient(ModBlocks.psimetalPlateBlack.asItem())
+		);
+		buildMagicalWrapper(Psi.location("psimetal_plate_white_light"), consumer,
+				hasPsimetal, "has_psimetal",
+				ShapelessRecipeBuilder.shapelessRecipe(ModBlocks.psimetalPlateWhiteLight.asItem())
+						.addIngredient(Tags.Items.DUSTS_GLOWSTONE)
+						.addIngredient(ModBlocks.psimetalPlateWhite.asItem())
+		);
+	}
 
-    private static void specialRecipe(SpecialRecipeSerializer<?> serializer, Consumer<IFinishedRecipe> consumer) {
-        CustomRecipeBuilder.func_218656_a(serializer).build(consumer, serializer.getRegistryName().toString());
-    }
+	private static void buildMagicalWrapper(ResourceLocation id, Consumer<IFinishedRecipe> consumer,
+											ICriterionInstance recipeUnlockCriterion, String criterionName, ShapelessRecipeBuilder builder) {
+		builder.addCriterion(criterionName, recipeUnlockCriterion);
+		buildMagicalWrapper(id, consumer, recipeUnlockCriterion, criterionName, builder::build);
+	}
+
+	private static void buildMagicalWrapper(ResourceLocation id, Consumer<IFinishedRecipe> consumer,
+											ICriterionInstance recipeUnlockCriterion, String criterionName, ShapedRecipeBuilder builder) {
+		builder.addCriterion(criterionName, recipeUnlockCriterion);
+		buildMagicalWrapper(id, consumer, recipeUnlockCriterion, criterionName, builder::build);
+	}
+
+	private static void buildMagicalWrapper(ResourceLocation id, Consumer<IFinishedRecipe> consumer, ICriterionInstance criterion,
+											String criterionName, Consumer<Consumer<IFinishedRecipe>> recipe) {
+		ConditionalRecipe.builder()
+				.addCondition(new NotCondition(MagicalPsiCondition.INSTANCE))
+				.addRecipe(recipe)
+				.setAdvancement(Psi.location("recipe/" + id.getPath()), new ConditionalAdvancement.Builder()
+						.addCondition(new NotCondition(MagicalPsiCondition.INSTANCE))
+						.addAdvancement(Advancement.Builder.builder()
+								.withParentId(new ResourceLocation("recipes/root"))
+								.withRewards(AdvancementRewards.Builder.recipe(id))
+								.withCriterion(criterionName, criterion)
+								.withCriterion("has_the_recipe", new RecipeUnlockedTrigger.Instance(id))
+								.withRequirementsStrategy(IRequirementsStrategy.OR)))
+				.build(consumer, id);
+	}
+
+	private static void specialRecipe(SpecialRecipeSerializer<?> serializer, Consumer<IFinishedRecipe> consumer) {
+		CustomRecipeBuilder.func_218656_a(serializer).build(consumer, Psi.location("dynamic/" + serializer.getRegistryName().getPath()).toString());
+	}
 
 }


### PR DESCRIPTION
So, uh, yeah. Notable things:
* Fixed two tools not being registered at all. Good job Kame.
* All the recipes are now generated. They all have a condition for Magical Psi being disabled.
* All recipes have an advancement that awards them on an item pickup. Iron unlocks the basics, psidust unlocks like half of the mod, psimetal unlocks most of the remainder, and ebony/ivory psimetal unlock things that take them, with a few one-offs for recipes that don't really fit.
* Tags were slightly rearranged. Blocks get tags for both the block and item form now, and psigem/psimetal/psidust tags are no longer share `<type>/psi` so that mods with automated material processing don't try to make the three craftable into each other like it was common in the 1.12 era.

I renamed the magipsi condition a little bit because it makes no sense to not just use `forge:mod_loaded` in that case, unless we make it possible to disable the recipes only.