### PR TITLE
Add Patchouli spell piece component, spotlight page, and an example page

### DIFF
--- a/src/main/java/vazkii/psi/client/patchouli/SpellPieceComponent.java
+++ b/src/main/java/vazkii/psi/client/patchouli/SpellPieceComponent.java
@@ -1,0 +1,53 @@
+package vazkii.psi.client.patchouli;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import vazkii.patchouli.api.IComponentRenderContext;
+import vazkii.patchouli.api.ICustomComponent;
+import vazkii.psi.api.PsiAPI;
+import vazkii.psi.api.spell.Spell;
+import vazkii.psi.api.spell.SpellPiece;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SpellPieceComponent implements ICustomComponent {
+	private transient int x, y;
+	private transient SpellPiece piece;
+
+	private String name;
+
+	@Override
+	public void build(int componentX, int componentY, int pageNum) {
+		this.x = componentX;
+		this.y = componentY;
+		this.piece = PsiAPI.spellPieceRegistry.getValue(new ResourceLocation(name))
+				.map(clazz -> SpellPiece.create(clazz, new Spell()))
+				.orElseThrow(() -> new IllegalArgumentException("Invalid spell piece name: " + name));
+	}
+
+	@Override
+	public void render(IComponentRenderContext context, float pticks, int mouseX, int mouseY) {
+		IRenderTypeBuffer.Impl buffer = IRenderTypeBuffer.immediate(Tessellator.getInstance().getBuffer());
+		MatrixStack ms = new MatrixStack();
+		ms.translate(x, y, 0);
+		piece.draw(ms, buffer, 0xF000F0);
+		buffer.draw();
+
+		if (context.isAreaHovered(mouseX, mouseY, x - 1, y - 1, 16, 16)) {
+			List<ITextComponent> tooltip = new ArrayList<>();
+			piece.getTooltip(tooltip);
+			context.setHoverTooltip(tooltip.stream().map(ITextComponent::getFormattedText).collect(Collectors.toList()));
+		}
+	}
+
+	@Override
+	public void onVariablesAvailable(Function<String, String> function) {
+		name = function.apply(name);
+	}
+}

--- a/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/categories/basics.json
+++ b/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/categories/basics.json
@@ -1,0 +1,6 @@
+{
+  "name": "psi.book.category.basics",
+  "description": "psi.book.category.basics",
+  "icon": "psi:psidust",
+  "sortnum": 0
+}

--- a/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/entries/spotlight_test.json
+++ b/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/entries/spotlight_test.json
@@ -1,0 +1,30 @@
+{
+  "name": "Spell Piece Spotlight Test",
+  "category": "basics",
+  "icon": "psi:psidust",
+  "flag": "debug",
+  "pages": [
+    {
+      "type": "text",
+      "text": "This is an entry used purely for testing the spell piece component. You shouldn't be able to see it outside of a dev environment."
+    },
+    {
+      "type": "spellpiece_spotlight",
+      "title": "Trick: Greater Infusion",
+      "spellpiece": "psi:trick_greater_infusion",
+      "text": "PsiDust is now completely uncraftable, player is stuck at level 0 permanently No bypass commands work."
+    },
+    {
+      "type": "spotlight",
+      "title": "Trick: Greater Infusion",
+      "item": "psi:psidust",
+      "text": "Item spotlight page for comparison purposes."
+    },
+    {
+      "type": "spellpiece_spotlight",
+      "title": "Trick: Greater Infusion",
+      "spellpiece": "psi:trick_greater_infusion",
+      "text": "Spell piece spotlight, again."
+    }
+  ]
+}

--- a/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/templates/spellpiece_spotlight.json
+++ b/src/main/resources/data/psi/patchouli_books/taurus_silver_handbook/en_us/templates/spellpiece_spotlight.json
@@ -1,0 +1,34 @@
+{
+  "components": [
+    {
+      "type": "header",
+      "text": "#title",
+      "x": -1,
+      "y": -1
+    },
+    {
+      "type": "image",
+      "image": "patchouli:textures/gui/crafting.png",
+      "x": 25,
+      "y": 10,
+      "u": 0,
+      "v": 102,
+      "width": 66,
+      "height": 26,
+      "texture_width": 128,
+      "texture_height": 128
+    },
+    {
+      "type": "custom",
+      "class": "vazkii.psi.client.patchouli.SpellPieceComponent",
+      "x": 50,
+      "y": 15,
+      "name": "#spellpiece"
+    },
+    {
+      "type": "text",
+      "text": "#text",
+      "y": 40
+    }
+  ]
+}


### PR DESCRIPTION
* Spell piece component, takes x/y positions and piece registry name.
* Spell piece spotlight template, basically a copy of the Patchouli item spotlight but done as a template.
* Example page for usage of the spotlight template. It is kept as a debug entry so it doesn't show up in actual builds of the mod.