### PR TITLE
Fix harvesting tool

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellContext.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellContext.java
@@ -199,4 +199,18 @@ public final class SpellContext {
 		return slot;
 	}
 
+	/**
+	 * Gets the tool to use for harvesting purposes.
+	 * @return tool if it has tool classes, otherwise the caster's cad, otherwise raises exception
+	 * @throws SpellRuntimeException NO_CAD
+	 */
+	public ItemStack getHarvestTool() throws SpellRuntimeException {
+		if (!tool.isEmpty() && !tool.getItem().getToolClasses(tool).isEmpty())
+			return tool;
+
+		ItemStack cad = PsiAPI.getPlayerCAD(caster);
+		if(cad.isEmpty())
+			throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
+		return cad;
+	}
 }

--- a/src/main/java/vazkii/psi/api/spell/SpellContext.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellContext.java
@@ -30,10 +30,6 @@ import java.util.Stack;
  */
 public final class SpellContext {
 
-	public SpellContext(ItemStack cad) {
-		this.cad = cad;
-	}
-
 	/**
 	 * The maximum distance from the spell's {@link #focalPoint} a piece of the spell can interact with.<br>
 	 * This should be checked against in any tricks that affect parts of the world given a position
@@ -41,11 +37,6 @@ public final class SpellContext {
 	 * @see #isInRadius(Entity), {@link #isInRadius(Vector3)}, {@link #isInRadius(double, double, double)}
 	 */
 	public static final double MAX_DISTANCE = 32;
-
-	/**
-	 * The CAD used to cast this spell.
-	 */
-	public ItemStack cad;
 
 	/**
 	 * The player casting this spell.

--- a/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
+++ b/src/main/java/vazkii/psi/client/render/entity/RenderSpellCircle.java
@@ -18,8 +18,6 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import vazkii.psi.api.cad.EnumCADComponent;
-import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
 import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.common.Psi;
@@ -47,14 +45,9 @@ public class RenderSpellCircle extends Render<EntitySpellCircle> {
 		super.doRender(entity, x, y, z, entityYaw, partialTicks);
 
 		int colorVal = ICADColorizer.DEFAULT_SPELL_COLOR;
-
-		ItemStack cad = entity.getDataManager().get(EntitySpellCircle.CAD_DATA);
-		if(!cad.isEmpty() && cad.getItem() instanceof ICAD) {
-			ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
-			if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
-				colorVal = Psi.proxy.getColorForColorizer(colorizer);
-		}
-
+		ItemStack colorizer = entity.getDataManager().get(EntitySpellCircle.COLORIZER_DATA);
+		if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
+			colorVal = Psi.proxy.getColorForColorizer(colorizer);
 		float alive = entity.getTimeAlive() + partialTicks;
 		float s1 = Math.min(1F, alive / EntitySpellCircle.CAST_DELAY);
 		if(alive > EntitySpellCircle.LIVE_TIME - EntitySpellCircle.CAST_DELAY)

--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -409,7 +409,7 @@ public class PlayerDataHandler {
 
 						ISpellAcceptor spellContainer = ISpellAcceptor.acceptor(bullet);
 						Spell spell = spellContainer.getSpell();
-						SpellContext context = new SpellContext(cadStack).setPlayer(player).setSpell(spell).setLoopcastIndex(loopcastAmount + 1);
+						SpellContext context = new SpellContext().setPlayer(player).setSpell(spell).setLoopcastIndex(loopcastAmount + 1);
 						if(context.isValid()) {
 							if(context.cspell.metadata.evaluateAgainst(cadStack)) {
 								int cost = ItemCAD.getRealCost(cadStack, bullet, context.cspell.metadata.stats.get(EnumSpellStat.COST));

--- a/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
+++ b/src/main/java/vazkii/psi/common/entity/EntitySpellCircle.java
@@ -21,8 +21,6 @@ import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import vazkii.psi.api.cad.EnumCADComponent;
-import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.cad.ICADColorizer;
 import vazkii.psi.api.spell.*;
 import vazkii.psi.api.internal.PsiRenderHelper;
@@ -37,7 +35,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 	public static final int CAST_DELAY = 5;
 	public static final int LIVE_TIME = (CAST_TIMES + 2) * CAST_DELAY;
 
-	private static final String TAG_CAD = "cad";
+	private static final String TAG_COLORIZER = "colorizer";
 	private static final String TAG_BULLET = "bullet";
 	private static final String TAG_CASTER = "caster";
 	private static final String TAG_TIME_ALIVE = "timeAlive";
@@ -48,7 +46,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 	private static final String TAG_LOOK_Z = "savedLookZ";
 
 	// Generics are borked :|
-	public static final DataParameter<ItemStack> CAD_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
+	public static final DataParameter<ItemStack> COLORIZER_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<ItemStack> BULLET_DATA = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.ITEM_STACK);
 	private static final DataParameter<String> CASTER_NAME = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.STRING);
 	private static final DataParameter<Integer> TIME_ALIVE = EntityDataManager.createKey(EntitySpellCircle.class, DataSerializers.VARINT);
@@ -63,8 +61,8 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 		setSize(3F, 0F);
 	}
 
-	public EntitySpellCircle setInfo(EntityPlayer player, ItemStack cad, ItemStack bullet) {
-		dataManager.set(CAD_DATA, cad);
+	public EntitySpellCircle setInfo(EntityPlayer player, ItemStack colorizer, ItemStack bullet) {
+		dataManager.set(COLORIZER_DATA,colorizer);
 		dataManager.set(BULLET_DATA, bullet);
 		dataManager.set(CASTER_NAME, player.getName());
 
@@ -77,7 +75,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	protected void entityInit() {
-		dataManager.register(CAD_DATA, new ItemStack(Blocks.STONE));
+		dataManager.register(COLORIZER_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(BULLET_DATA, new ItemStack(Blocks.STONE));
 		dataManager.register(CASTER_NAME, "");
 		dataManager.register(TIME_ALIVE, 0);
@@ -89,11 +87,11 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	public void writeEntityToNBT(@Nonnull NBTTagCompound tagCompound) {
-		NBTTagCompound cadCmp = new NBTTagCompound();
-		ItemStack cad = dataManager.get(CAD_DATA);
-		if(!cad.isEmpty())
-			cad.writeToNBT(cadCmp);
-		tagCompound.setTag(TAG_CAD, cadCmp);
+		NBTTagCompound colorizerCmp = new NBTTagCompound();
+		ItemStack colorizer =  dataManager.get(COLORIZER_DATA);
+		if (!colorizer.isEmpty())
+			colorizer.writeToNBT(colorizerCmp);
+		tagCompound.setTag(TAG_COLORIZER, colorizerCmp);
 
 		NBTTagCompound bulletCmp = new NBTTagCompound();
 		ItemStack bullet = dataManager.get(BULLET_DATA);
@@ -112,9 +110,9 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 	@Override
 	public void readEntityFromNBT(@Nonnull NBTTagCompound tagCompound) {
-		NBTTagCompound cadCmp = tagCompound.getCompoundTag(TAG_CAD);
-		ItemStack cad = new ItemStack(cadCmp);
-		dataManager.set(CAD_DATA, cad);
+		NBTTagCompound colorizerCmp = tagCompound.getCompoundTag(TAG_COLORIZER);
+		ItemStack colorizer = new ItemStack(colorizerCmp);
+		dataManager.set(COLORIZER_DATA, colorizer);
 
 		NBTTagCompound bulletCmp = tagCompound.getCompoundTag(TAG_BULLET);
 		ItemStack bullet = new ItemStack(bulletCmp);
@@ -139,7 +137,6 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 
 		setTimeAlive(timeAlive + 1);
 		int times = dataManager.get(TIMES_CAST);
-		ItemStack cad = dataManager.get(CAD_DATA);
 
 		if (timeAlive > CAST_DELAY && timeAlive % CAST_DELAY == 0 && times < 20) {
 			SpellContext context = null;
@@ -150,7 +147,7 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 					dataManager.set(TIMES_CAST, times + 1);
 					Spell spell = ISpellAcceptor.acceptor(spellContainer).getSpell();
 					if (spell != null)
-						context = new SpellContext(cad).setPlayer((EntityPlayer) thrower).setFocalPoint(this)
+						context = new SpellContext().setPlayer((EntityPlayer) thrower).setFocalPoint(this)
 								.setSpell(spell).setLoopcastIndex(times);
 				}
 			}
@@ -160,12 +157,9 @@ public class EntitySpellCircle extends Entity implements ISpellImmune {
 		}
 
 		int colorVal = ICADColorizer.DEFAULT_SPELL_COLOR;
-		if(!cad.isEmpty() && cad.getItem() instanceof ICAD) {
-			ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
-			if(!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
-				colorVal = Psi.proxy.getColorForColorizer(colorizer);
-		}
-
+		ItemStack colorizer = dataManager.get(COLORIZER_DATA);
+		if (!colorizer.isEmpty() && colorizer.getItem() instanceof ICADColorizer)
+			colorVal = Psi.proxy.getColorForColorizer(colorizer);
 
 		float r = PsiRenderHelper.r(colorVal) / 255F;
 		float g = PsiRenderHelper.g(colorVal) / 255F;

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -99,6 +99,10 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 
 		new AssemblyScavengeRecipe();
 		setCreativeTab(PsiCreativeTab.INSTANCE);
+
+		setHarvestLevel("pickaxe", ConfigHandler.cadHarvestLevel);
+		setHarvestLevel("axe", ConfigHandler.cadHarvestLevel);
+		setHarvestLevel("shovel", ConfigHandler.cadHarvestLevel);
 	}
 
 	private ICADData getCADData(ItemStack stack) {
@@ -540,30 +544,6 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		if(memorySlot < 0 || memorySlot >= size)
 			throw new SpellRuntimeException(SpellRuntimeException.MEMORY_OUT_OF_BOUNDS);
 		return getCADData(stack).getSavedVector(memorySlot);
-	}
-
-	// Based on ItemTool::getHarvestLevel
-	@Override
-	public int getHarvestLevel(ItemStack stack, @Nonnull String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState) {
-		int level = super.getHarvestLevel(stack, toolClass, player, blockState);
-		if(level == -1 && getToolClasses(stack).contains(toolClass))
-			return ConfigHandler.cadHarvestLevel;
-		else
-			return level;
-	}
-
-	@Nonnull
-	@Override
-	public Set<String> getToolClasses(ItemStack stack) {
-		return ImmutableSet.of("pickaxe", "axe", "shovel");
-	}
-
-	@Override
-	public boolean canHarvestBlock(@Nonnull IBlockState state, ItemStack stack) {
-		Block block = state.getBlock();
-		String tool = block.getHarvestTool(state);
-		int level = block.getHarvestLevel(state);
-		return getHarvestLevel(stack, tool, null, state) >= level;
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -214,7 +214,7 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		if (!data.overflowed && data.getAvailablePsi() > 0 && !cad.isEmpty() && !bullet.isEmpty() && ISpellAcceptor.hasSpell(bullet) && isTruePlayer(player)) {
 			ISpellAcceptor spellContainer = ISpellAcceptor.acceptor(bullet);
 			Spell spell = spellContainer.getSpell();
-			SpellContext context = new SpellContext(cad).setPlayer(player).setSpell(spell);
+			SpellContext context = new SpellContext().setPlayer(player).setSpell(spell);
 			if (predicate != null)
 				predicate.accept(context);
 

--- a/src/main/java/vazkii/psi/common/item/ItemSpellBullet.java
+++ b/src/main/java/vazkii/psi/common/item/ItemSpellBullet.java
@@ -26,6 +26,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.arl.item.ItemMod;
 import vazkii.arl.util.ItemNBTHelper;
 import vazkii.psi.api.PsiAPI;
+import vazkii.psi.api.cad.EnumCADComponent;
+import vazkii.psi.api.cad.ICAD;
 import vazkii.psi.api.internal.TooltipHelper;
 import vazkii.psi.api.spell.ISpellContainer;
 import vazkii.psi.api.spell.Spell;
@@ -138,6 +140,7 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 	@Override
 	public void castSpell(ItemStack stack, SpellContext context) {
 		ItemStack cad = PsiAPI.getPlayerCAD(context.caster);
+		ItemStack colorizer = ((ICAD) cad.getItem()).getComponentInSlot(cad, EnumCADComponent.DYE);
 
 		EntitySpellProjectile projectile = null;
 
@@ -168,7 +171,7 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 
 				if (pos != null) {
 					EntitySpellCircle circle = new EntitySpellCircle(context.caster.getEntityWorld());
-					circle.setInfo(context.caster, cad, stack);
+					circle.setInfo(context.caster, colorizer, stack);
 					circle.setPosition(pos.hitVec.x, pos.hitVec.y, pos.hitVec.z);
 					circle.getEntityWorld().spawnEntity(circle);
 				}
@@ -189,7 +192,7 @@ public class ItemSpellBullet extends ItemMod implements ISpellContainer, IPsiIte
 		}
 
 		if (projectile != null) {
-			projectile.setInfo(context.caster, cad, stack);
+			projectile.setInfo(context.caster, colorizer, stack);
 			projectile.context = context;
 			projectile.getEntityWorld().spawnEntity(projectile);
 		}

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -89,6 +89,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 					if(block.removedByPlayer(state, world, pos, player, true)) {
 						block.onPlayerDestroy(world, pos, state);
 						block.harvestBlock(world, player, pos, state, tile, tool);
+						block.dropXpOnBlockBreak(world, pos, event.getExpToDrop());
 					}
 				} else world.setBlockToAir(pos);
 			}

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -53,6 +53,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 
 	@Override
 	public Object execute(SpellContext context) throws SpellRuntimeException {
+		ItemStack tool = context.getHarvestTool();
 		Vector3 positionVal = this.getParamValue(context, position);
 
 		if(positionVal == null)
@@ -61,7 +62,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 		BlockPos pos = positionVal.toBlockPos();
-		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), context.tool, pos, true);
+		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), tool, pos, true);
 
 		return null;
 	}

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -76,7 +76,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 
 		IBlockState state = world.getBlockState(pos);
 		Block block = state.getBlock();
-		if(!block.isAir(state, world, pos) && !(block instanceof BlockLiquid) && !(block instanceof IFluidBlock) && state.getBlockHardness(world, pos) > 0) {
+		if(!block.isAir(state, world, pos) && !(block instanceof BlockLiquid) && !(block instanceof IFluidBlock) && state.getBlockHardness(world, pos) != -1) {
 			if(!canHarvestBlock(block, player, world, pos, tool))
 				return;
 

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -60,18 +60,8 @@ public class PieceTrickBreakBlock extends PieceTrick {
 		if(!context.isInRadius(positionVal))
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
-		ItemStack tool = context.tool;
-		if(tool.isEmpty()) {
-			tool = PsiAPI.getPlayerCAD(context.caster);
-			if(tool.isEmpty()) {
-				tool = context.cad;
-				if(tool.isEmpty())
-					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
-			}
-		}
-
 		BlockPos pos = positionVal.toBlockPos();
-		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), tool, pos, true);
+		removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), context.tool, pos, true);
 
 		return null;
 	}
@@ -79,6 +69,9 @@ public class PieceTrickBreakBlock extends PieceTrick {
 	public static void removeBlockWithDrops(SpellContext context, EntityPlayer player, World world, ItemStack tool, BlockPos pos, boolean particles) {
 		if(!world.isBlockLoaded(pos) || (context.positionBroken != null && pos.equals(context.positionBroken.getBlockPos())) || !world.isBlockModifiable(player, pos))
 			return;
+
+		if (tool.isEmpty())
+			tool = PsiAPI.getPlayerCAD(player);
 
 		IBlockState state = world.getBlockState(pos);
 		Block block = state.getBlock();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakInSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakInSequence.java
@@ -10,6 +10,7 @@
  */
 package vazkii.psi.common.spell.trick.block;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.EnumSpellStat;
@@ -54,6 +55,7 @@ public class PieceTrickBreakInSequence extends PieceTrick {
 
 	@Override
 	public Object execute(SpellContext context) throws SpellRuntimeException {
+		ItemStack tool = context.getHarvestTool();
 		Vector3 positionVal = this.getParamValue(context, position);
 		Vector3 targetVal = this.getParamValue(context, target);
 		Double maxBlocksVal = this.<Double>getParamValue(context, maxBlocks);
@@ -71,7 +73,7 @@ public class PieceTrickBreakInSequence extends PieceTrick {
 				throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 			BlockPos pos = blockVec.toBlockPos();
-			PieceTrickBreakBlock.removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), context.tool, pos, true);
+			PieceTrickBreakBlock.removeBlockWithDrops(context, context.caster, context.caster.getEntityWorld(), tool, pos, true);
 		}
 
 		return null;

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
@@ -48,16 +48,13 @@ public class PieceTrickCollapseBlock extends PieceTrick {
 
 	@Override
 	public Object execute(SpellContext context) throws SpellRuntimeException {
+		ItemStack tool = context.getHarvestTool();
 		Vector3 positionVal = this.getParamValue(context, position);
 
 		if(positionVal == null)
 			throw new SpellRuntimeException(SpellRuntimeException.NULL_VECTOR);
 		if(!context.isInRadius(positionVal))
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
-
-		ItemStack tool = context.tool;
-		if (tool.isEmpty())
-			tool = PsiAPI.getPlayerCAD(context.caster);
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
@@ -56,14 +56,8 @@ public class PieceTrickCollapseBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 		ItemStack tool = context.tool;
-		if(tool.isEmpty()) {
+		if (tool.isEmpty())
 			tool = PsiAPI.getPlayerCAD(context.caster);
-			if(tool.isEmpty()) {
-				tool = context.cad;
-				if(tool.isEmpty())
-					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
-			}
-		}
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -58,14 +58,8 @@ public class PieceTrickMoveBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
 
 		ItemStack tool = context.tool;
-		if(tool.isEmpty()) {
+		if (tool.isEmpty())
 			tool = PsiAPI.getPlayerCAD(context.caster);
-			if(tool.isEmpty()) {
-				tool = context.cad;
-				if(tool.isEmpty())
-					throw new SpellRuntimeException(SpellRuntimeException.NO_CAD);
-			}
-		}
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -49,6 +49,7 @@ public class PieceTrickMoveBlock extends PieceTrick {
 
 	@Override
 	public Object execute(SpellContext context) throws SpellRuntimeException {
+		ItemStack tool = context.getHarvestTool();
 		Vector3 positionVal = this.getParamValue(context, position);
 		Vector3 targetVal = this.getParamValue(context, target);
 
@@ -56,10 +57,6 @@ public class PieceTrickMoveBlock extends PieceTrick {
 			throw new SpellRuntimeException(SpellRuntimeException.NULL_VECTOR);
 		if(!context.isInRadius(positionVal))
 			throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
-
-		ItemStack tool = context.tool;
-		if (tool.isEmpty())
-			tool = PsiAPI.getPlayerCAD(context.caster);
 
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -64,7 +64,7 @@ public class PieceTrickMoveBlock extends PieceTrick {
 		Block block = state.getBlock();
 		if(world.getTileEntity(pos) != null || state.getPushReaction() != EnumPushReaction.NORMAL ||
 				!block.canSilkHarvest(world, pos, state, context.caster) ||
-				state.getBlockHardness(world, pos) <= 0 ||
+				state.getBlockHardness(world, pos) == -1 ||
 				!PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, pos, tool))
 			return null;
 		


### PR DESCRIPTION
Partially reverts https://github.com/Vazkii/Psi/pull/540 (commit https://github.com/Vazkii/Psi/pull/540/commits/bd3c6be639f9f2d1b65b6d43af03e7c13334c11a) as it is a copy of the CAD and some spells require the actual CAD like Save Vector.

Adds a method in SpellContext that gets the tool that is used for harvesting. This fixes the previous PR not working with Psi Metal Armour. Now it uses the CAD if the Psi Metal Tool in the context does not have any tool classes.

Switched to using setHarvestLevel for ItemCAD so no longer need to override a bunch of methods. One downside to this is that a restart is required to reflect config changes.

Fixed experience orbs not dropping from broken blocks. (was missing some code that is usually called in `PlayerInteractionManager#tryHarvestBlock`).

Fixed a bug in the previous PR that made instant break blocks like torches and grass unbreakable. This was because in switching from `getPlayerRelativeHardness` to `getBlockHardness` it turns out that the former is actually the inverse of hardness, calling `blockStrength`. Tested this to make sure that it doesn't break bedrock (See how BlockPistonBase uses getBlockHardness).

[Testing Video](https://www.youtube.com/watch?v=IUHydELohJg)