### PR TITLE
Make CAD only act as a tool during harvest check

### DIFF
--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -70,10 +70,12 @@ import vazkii.psi.common.item.component.ItemCADSocket;
 import vazkii.psi.common.lib.LibItemNames;
 import vazkii.psi.common.network.message.MessageCADDataSync;
 import vazkii.psi.common.network.message.MessageVisualEffect;
+import vazkii.psi.common.spell.trick.block.PieceTrickBreakBlock;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -171,13 +173,6 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		ItemStack stack = playerIn.getHeldItem(hand);
 		Block block = worldIn.getBlockState(pos).getBlock(); 
 		return block == ModBlocks.programmer ? ((BlockProgrammer) block).setSpell(worldIn, pos, playerIn, stack) : EnumActionResult.PASS;
-	}
-
-	@Override
-	public float getDestroySpeed(ItemStack stack, IBlockState state) {
-		if(state.getMaterial().isToolNotRequired())
-			return 1.0f;
-		return 0.0f;
 	}
 
 	@Nonnull
@@ -550,6 +545,23 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		return getCADData(stack).getSavedVector(memorySlot);
 	}
 
+	@Override
+	public int getHarvestLevel(ItemStack stack, @Nonnull String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return -1;
+		}
+		return super.getHarvestLevel(stack, toolClass, player, blockState);
+	}
+
+	@Nonnull
+	@Override
+	public Set<String> getToolClasses(ItemStack stack) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return Collections.emptySet();
+		}
+		return super.getToolClasses(stack);
+	}
+
 	/**
 	 * Mostly handled by forge assigning tool classes to vanilla blocks {@link ForgeHooks#initTools()}.
 	 * Currently this only needs Materials special cased to match the vanilla pickaxe but this may change.
@@ -559,6 +571,9 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 	 */
 	@Override
 	public boolean canHarvestBlock(@Nonnull IBlockState state, ItemStack stack) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return super.canHarvestBlock(state, stack);
+		}
 		Block block = state.getBlock();
 		String tool = block.getHarvestTool(state);
 		int level = tool == null ? -1 : getHarvestLevel(stack, tool, null, state);


### PR DESCRIPTION
This makes the CAD only act as a tool while a harvest check is ongoing.
It also sets the main hand to the tool stack and then resets the main hand back to the previous stack after the check is done (so that we can just use `block.canHarvestBlock(world, pos, player)` and have better compatiblity). Ideally this would be swapping the stacks but then we'd need to pass the slot the tool is in rather than just the tool stack in that case.

The createBreakEvent could possibly use a similar change since right now listeners to the event don't have access to the actual stack doing the harvesting. But this is quite the rabbit hole since mods may modify the main hand during that event...

Still need to take a look at maybe switching to using NBT instead of using global state as well. Was thinking this could possibly go into the ICAD interface in a more general way. Like a method `isCasting()` to check if the CAD is currently involved in casting a spell. Need to make sure that it is set and unset without a delay so players wouldn't be able to cheese this by using a spell circle and then breaking blocks while it's active. So typically `isCasting()` would return false except in e.g. event handlers.