### PR TITLE
Port 'Make CAD only act as a tool during harvest check' to 1.15

### DIFF
--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -71,11 +71,13 @@ import vazkii.psi.common.lib.LibPieceGroups;
 import vazkii.psi.common.network.MessageRegister;
 import vazkii.psi.common.network.message.MessageCADDataSync;
 import vazkii.psi.common.network.message.MessageVisualEffect;
+import vazkii.psi.common.spell.trick.block.PieceTrickBreakBlock;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -174,14 +176,6 @@ public class ItemCAD extends Item implements ICAD {
 		ItemStack stack = playerIn.getHeldItem(hand);
 		Block block = worldIn.getBlockState(pos).getBlock();
 		return block == ModBlocks.programmer ? ((BlockProgrammer) block).setSpell(worldIn, pos, playerIn, stack) : ActionResultType.PASS;
-	}
-
-	@Override
-	public float getDestroySpeed(ItemStack stack, BlockState state) {
-		if (state.getMaterial().isToolNotRequired()) {
-			return 1.0f;
-		}
-		return 0.0f;
 	}
 
 	@Nonnull
@@ -532,6 +526,23 @@ public class ItemCAD extends Item implements ICAD {
 		return getCADData(stack).getSavedVector(memorySlot);
 	}
 
+	@Override
+	public int getHarvestLevel(ItemStack stack, ToolType tool, @Nullable PlayerEntity player, @Nullable BlockState blockState) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return -1;
+		}
+		return super.getHarvestLevel(stack, tool, player, blockState);
+	}
+
+	@Nonnull
+	@Override
+	public Set<ToolType> getToolTypes(ItemStack stack) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return Collections.emptySet();
+		}
+		return super.getToolTypes(stack);
+	}
+
 	/**
 	 * Mostly handled by forge assigning tool classes to vanilla blocks in ForgeHooks#initTools().
 	 * Currently this only needs Materials special cased to match the vanilla pickaxe but this may change.
@@ -541,6 +552,9 @@ public class ItemCAD extends Item implements ICAD {
 	 */
 	@Override
 	public boolean canHarvestBlock(ItemStack stack, @Nonnull BlockState state) {
+		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
+			return super.canHarvestBlock(stack, state);
+		}
 		Block block = state.getBlock();
 		ToolType tool = block.getHarvestTool(state);
 		int level = tool == null ? -1 : getHarvestLevel(stack, tool, null, state);

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickBreakBlock.java
@@ -18,9 +18,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.extensions.IForgeBlock;
+import net.minecraftforge.common.extensions.IForgeBlockState;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.fluids.IFluidBlock;
 
@@ -89,7 +88,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 		BlockState state = world.getBlockState(pos);
 		Block block = state.getBlock();
 		if (!block.isAir(state, world, pos) && !(block instanceof IFluidBlock) && state.getBlockHardness(world, pos) != -1) {
-			if (!canHarvestBlock(block, player, world, pos, tool)) {
+			if (!canHarvestBlock(state, player, world, pos, tool)) {
 				return;
 			}
 
@@ -121,7 +120,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 	 */
 	public static BreakEvent createBreakEvent(BlockState state, PlayerEntity player, World world, BlockPos pos, ItemStack tool) {
 		BreakEvent event = new BreakEvent(world, pos, state, player);
-		if (state == null || !ForgeHooks.canHarvestBlock(state, player, world, pos)) // Handle empty block or player unable to break block scenario
+		if (state == null || !canHarvestBlock(state, player, world, pos, tool)) // Handle empty block or player unable to break block scenario
 		{
 			event.setExpToDrop(0);
 		} else {
@@ -135,9 +134,10 @@ public class PieceTrickBreakBlock extends PieceTrick {
 	/**
 	 * Item stack aware harvest check
 	 * Also sets global state {@link PieceTrickBreakBlock#doingHarvestCheck} to true during the check
-	 * @see IForgeBlock#canHarvestBlock(BlockState, IBlockReader, BlockPos, PlayerEntity)
+	 * 
+	 * @see IForgeBlockState#canHarvestBlock(IBlockReader, BlockPos, PlayerEntity)
 	 */
-	public static boolean canHarvestBlock(Block block, PlayerEntity player, World world, BlockPos pos, ItemStack stack) {
+	public static boolean canHarvestBlock(BlockState state, PlayerEntity player, World world, BlockPos pos, ItemStack stack) {
 		// So the CAD can only be used as a tool when a harvest check is ongoing
 		boolean wasChecking = doingHarvestCheck.get();
 		doingHarvestCheck.set(true);
@@ -149,7 +149,7 @@ public class PieceTrickBreakBlock extends PieceTrick {
 		player.inventory.mainInventory.set(player.inventory.currentItem, stack);
 
 		// Harvest check
-		boolean canHarvest = block.canHarvestBlock(world.getBlockState(pos), world, pos, player);
+		boolean canHarvest = state.canHarvestBlock(world, pos, player);
 
 		// Swap back the main hand
 		player.inventory.mainInventory.set(player.inventory.currentItem, oldHeldStack);

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlock.java
@@ -8,7 +8,6 @@
  */
 package vazkii.psi.common.spell.trick.block;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.item.ItemStack;
@@ -17,7 +16,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.BlockEvent;
 
-import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.*;
 import vazkii.psi.api.spell.param.ParamVector;
@@ -61,14 +59,13 @@ public class PieceTrickCollapseBlock extends PieceTrick {
 		BlockPos posDown = pos.down();
 		BlockState state = world.getBlockState(pos);
 		BlockState stateDown = world.getBlockState(posDown);
-		Block block = state.getBlock();
 
 		if (!world.isBlockModifiable(context.caster, pos)) {
 			return null;
 		}
 
 		if (stateDown.isAir(world, posDown) && state.getBlockHardness(world, pos) != -1 &&
-				PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, pos, tool) &&
+				PieceTrickBreakBlock.canHarvestBlock(state, context.caster, world, pos, tool) &&
 				world.getTileEntity(pos) == null) {
 
 			BlockEvent.BreakEvent event = PieceTrickBreakBlock.createBreakEvent(state, context.caster, world, pos, tool);

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlockSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickCollapseBlockSequence.java
@@ -8,7 +8,6 @@
  */
 package vazkii.psi.common.spell.trick.block;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.item.ItemStack;
@@ -79,14 +78,13 @@ public class PieceTrickCollapseBlockSequence extends PieceTrick {
 			BlockPos posDown = blockPos.down();
 			BlockState state = world.getBlockState(blockPos);
 			BlockState stateDown = world.getBlockState(posDown);
-			Block block = state.getBlock();
 
 			if (!world.isBlockModifiable(context.caster, blockPos)) {
 				return null;
 			}
 
 			if (stateDown.isAir(world, posDown) && state.getBlockHardness(world, blockPos) != -1 &&
-					PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, blockPos, tool) &&
+					PieceTrickBreakBlock.canHarvestBlock(state, context.caster, world, blockPos, tool) &&
 					world.getTileEntity(blockPos) == null) {
 
 				BlockEvent.BreakEvent event = PieceTrickBreakBlock.createBreakEvent(state, context.caster, world, blockPos, tool);

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlock.java
@@ -17,7 +17,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.BlockEvent;
 
-import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.internal.Vector3;
 import vazkii.psi.api.spell.EnumSpellStat;
 import vazkii.psi.api.spell.Spell;
@@ -68,10 +67,9 @@ public class PieceTrickMoveBlock extends PieceTrick {
 		World world = context.caster.getEntityWorld();
 		BlockPos pos = positionVal.toBlockPos();
 		BlockState state = world.getBlockState(pos);
-		Block block = state.getBlock();
 		if (world.getTileEntity(pos) != null || state.getPushReaction() != PushReaction.NORMAL ||
 				state.getBlockHardness(world, pos) == -1 ||
-				!PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, pos, tool)) {
+				!PieceTrickBreakBlock.canHarvestBlock(state, context.caster, world, pos, tool)) {
 			return null;
 		}
 

--- a/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlockSequence.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/block/PieceTrickMoveBlockSequence.java
@@ -79,12 +79,11 @@ public class PieceTrickMoveBlockSequence extends PieceTrick {
 		for (BlockPos blockPos : positions) {
 			World world = context.caster.world;
 			BlockState state = world.getBlockState(blockPos);
-			Block block = state.getBlock();
 
 			if (world.getTileEntity(blockPos) != null ||
 					state.getPushReaction() != PushReaction.NORMAL ||
 					state.getPlayerRelativeBlockHardness(context.caster, world, blockPos) <= 0 ||
-					!PieceTrickBreakBlock.canHarvestBlock(block, context.caster, world, blockPos, context.tool) ||
+					!PieceTrickBreakBlock.canHarvestBlock(state, context.caster, world, blockPos, context.tool) ||
 					!SpellHelpers.isBlockPosInRadius(context, blockPos) ||
 					!world.isBlockModifiable(context.caster, blockPos) ||
 					world.isAirBlock(blockPos)) {

--- a/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickAddMotion.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/entity/PieceTrickAddMotion.java
@@ -113,7 +113,7 @@ public class PieceTrickAddMotion extends PieceTrick {
 		}
 
 		if (e instanceof ServerPlayerEntity) {
-			MessageAdditiveMotion motion = new MessageAdditiveMotion(e.getEntityId(), x,y ,z);
+			MessageAdditiveMotion motion = new MessageAdditiveMotion(e.getEntityId(), x, y, z);
 			MessageRegister.sendToPlayer(motion, (ServerPlayerEntity) e);
 		} else {
 			AdditiveMotionHandler.addMotion(e, x, y, z);


### PR DESCRIPTION
Ports https://github.com/Vazkii/Psi/pull/586 to 1.15
Also includes a commit that switches from using Block to BlockState (since that seems to be the correct way to do it in 1.15, and fixes createBreakEvent to use our canHarvestBlock (experience now properly drops from blocks)