### PR TITLE
Fix CAD harvest level not updating with config

### DIFF
--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -106,9 +106,9 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		new AssemblyScavengeRecipe();
 		setCreativeTab(PsiCreativeTab.INSTANCE);
 
-		setHarvestLevel("pickaxe", ConfigHandler.cadHarvestLevel);
-		setHarvestLevel("axe", ConfigHandler.cadHarvestLevel);
-		setHarvestLevel("shovel", ConfigHandler.cadHarvestLevel);
+		setHarvestLevel("pickaxe", 0);
+		setHarvestLevel("axe", 0);
+		setHarvestLevel("shovel", 0);
 	}
 
 	private ICADData getCADData(ItemStack stack) {
@@ -550,7 +550,8 @@ public class ItemCAD extends ItemMod implements ICAD, ISpellSettable, IItemColor
 		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
 			return -1;
 		}
-		return super.getHarvestLevel(stack, toolClass, player, blockState);
+		int level = super.getHarvestLevel(stack, toolClass, player, blockState);
+		return level < 0 ? -1 : Math.max(level, ConfigHandler.cadHarvestLevel);
 	}
 
 	@Nonnull


### PR DESCRIPTION
This PR has the cad harvest level update properly while in-game again (a previous PR of mine broke this feature by changing it to setting the harvest level in the constructor, which, in 1.15.2, the config is not loaded at that point).

[Video](https://www.youtube.com/watch?v=gcBohEG_rxE)

This PR will also fix https://github.com/Vazkii/Psi/issues/591 once it is ported to 1.15.2. But that might need some more changes.