### PR TITLE
Port 'Fix CAD harvest level not updating with config' and Fix config registration

### DIFF
--- a/src/main/java/vazkii/psi/common/Psi.java
+++ b/src/main/java/vazkii/psi/common/Psi.java
@@ -56,6 +56,8 @@ public class Psi {
 		instance = this;
 		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::commonSetup);
 		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::loadComplete);
+		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigHandler.CLIENT_SPEC);
+		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, ConfigHandler.COMMON_SPEC);
 		proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> ServerProxy::new);
 		proxy.registerHandlers();
 	}
@@ -65,9 +67,6 @@ public class Psi {
 		PsiAPI.internalHandler = new InternalMethodHandler();
 
 		CrashReportExtender.registerCrashCallable(new CrashReportHandler());
-
-		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigHandler.CLIENT_SPEC);
-		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, ConfigHandler.COMMON_SPEC);
 
 		DefaultStats.registerStats();
 		ModSpellPieces.init();

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -103,9 +103,9 @@ public class ItemCAD extends Item implements ICAD {
 	public ItemCAD(Item.Properties properties) {
 		super(properties
 				.maxStackSize(1)
-				.addToolType(ToolType.PICKAXE, ConfigHandler.COMMON.cadHarvestLevel.get())
-				.addToolType(ToolType.AXE, ConfigHandler.COMMON.cadHarvestLevel.get())
-				.addToolType(ToolType.SHOVEL, ConfigHandler.COMMON.cadHarvestLevel.get())
+				.addToolType(ToolType.PICKAXE, 0)
+				.addToolType(ToolType.AXE, 0)
+				.addToolType(ToolType.SHOVEL, 0)
 		);
 	}
 
@@ -531,7 +531,8 @@ public class ItemCAD extends Item implements ICAD {
 		if (!PieceTrickBreakBlock.doingHarvestCheck.get()) {
 			return -1;
 		}
-		return super.getHarvestLevel(stack, tool, player, blockState);
+		int level = super.getHarvestLevel(stack, tool, player, blockState);
+		return level < 0 ? -1 : Math.max(level, ConfigHandler.COMMON.cadHarvestLevel.get());
 	}
 
 	@Nonnull


### PR DESCRIPTION
Ports https://github.com/Vazkii/Psi/pull/592 to 1.15

Also moves the config registration to the mod constructor (see `net.minecraftforge.common.ForgeMod`).

This PR fixes https://github.com/Vazkii/Psi/issues/591

[Video](https://www.youtube.com/watch?v=G0orh3Lw1ks)