### PR TITLE
Fix lack of sensor colors

### DIFF
--- a/src/main/java/vazkii/psi/client/core/handler/ColorHandler.java
+++ b/src/main/java/vazkii/psi/client/core/handler/ColorHandler.java
@@ -22,7 +22,7 @@ public class ColorHandler {
 
 	public static void init() {
 		ItemColors items = Minecraft.getInstance().getItemColors();
-		items.register((stack, tintIndex) -> tintIndex == 1 ? ((ItemPsimetalArmor) stack.getItem()).getColor(stack) : 0xFFFFFF, ModItems.psimetalExosuitBoots, ModItems.psimetalExosuitChestplate, ModItems.psimetalExosuitBoots, ModItems.psimetalExosuitLeggings);
+		items.register((stack, tintIndex) -> tintIndex == 1 ? ((ItemPsimetalArmor) stack.getItem()).getColor(stack) : 0xFFFFFF, ModItems.psimetalExosuitBoots, ModItems.psimetalExosuitChestplate, ModItems.psimetalExosuitHelmet, ModItems.psimetalExosuitLeggings);
 
 		items.register((stack, tintIndex) -> tintIndex == 1 ? ((ItemExosuitSensor) stack.getItem()).getColor(stack) : 0xFFFFFF, ModItems.exosuitSensorHeat, ModItems.exosuitSensorLight, ModItems.exosuitSensorStress, ModItems.exosuitSensorWater, ModItems.exosuitSensorTrigger);
 

--- a/src/main/java/vazkii/psi/common/item/armor/ItemPsimetalArmor.java
+++ b/src/main/java/vazkii/psi/common/item/armor/ItemPsimetalArmor.java
@@ -173,7 +173,7 @@ public class ItemPsimetalArmor extends ArmorItem implements IPsimetalTool, IPsiE
 	@Override
 	public String getArmorTexture(ItemStack stack, Entity entity, EquipmentSlotType slot, String type) {
 		boolean overlay = type != null && type.equals("overlay");
-		return overlay ? LibResources.MODEL_PSIMETAL_EXOSUIT_SENSOR : LibResources.MODEL_PSIMETAL_EXOSUIT;
+		return overlay ? LibResources.MODEL_PSIMETAL_EXOSUIT : LibResources.MODEL_PSIMETAL_EXOSUIT_SENSOR;
 	}
 
 	public boolean hasColor(@Nonnull ItemStack stack) {

--- a/src/main/java/vazkii/psi/common/item/armor/ItemPsimetalExosuitHelmet.java
+++ b/src/main/java/vazkii/psi/common/item/armor/ItemPsimetalExosuitHelmet.java
@@ -9,6 +9,7 @@
 package vazkii.psi.common.item.armor;
 
 import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.IDyeableArmorItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
@@ -20,7 +21,8 @@ import vazkii.psi.api.exosuit.ISensorHoldable;
 
 import javax.annotation.Nonnull;
 
-public class ItemPsimetalExosuitHelmet extends ItemPsimetalArmor implements ISensorHoldable {
+public class ItemPsimetalExosuitHelmet extends ItemPsimetalArmor implements ISensorHoldable,
+		IDyeableArmorItem {
 
 	private static final String TAG_SENSOR = "sensor";
 


### PR DESCRIPTION
Currently, attaching sensors does not change the color of either the item or the model. The default color is also not present.

This PR addresses the three points needed to fix this:
1) Replace the mistaken double call to boots with the helmet when registering `ColorHandler` so that the helmet item colorizes the sensor correctly
2) Implement `IDyeableArmorItem` on `ItemPsimetalExosuitHelmet` so that the sensor's model gets rendered alongside the regular model
3) Reverse the logic in `ItemPsimetalArmor#getArmorTexture` so that the sensor's model gets colorized, because the "overlay" type actually represents the uncolored layer