### PR TITLE
Fix conjured blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url = 'https://files.minecraftforge.net/maven' }
-        maven { url = 'https://dist.creeper.host/Sponge/maven' }
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public' }
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true

--- a/src/main/java/vazkii/psi/common/block/BlockConjured.java
+++ b/src/main/java/vazkii/psi/common/block/BlockConjured.java
@@ -150,6 +150,11 @@ public class BlockConjured extends Block implements IWaterLoggable {
 	}
 
 	@Override
+	public VoxelShape getRayTraceShape(BlockState state, IBlockReader reader, BlockPos pos, ISelectionContext context) {
+		return VoxelShapes.empty();
+	}
+
+	@Override
 	public boolean propagatesSkylightDown(BlockState state, IBlockReader reader, BlockPos pos) {
 		return true;
 	}

--- a/src/main/java/vazkii/psi/common/block/base/ModBlocks.java
+++ b/src/main/java/vazkii/psi/common/block/base/ModBlocks.java
@@ -8,10 +8,12 @@
  */
 package vazkii.psi.common.block.base;
 
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.entity.EntityType;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -40,10 +42,12 @@ import static vazkii.psi.common.item.base.ModItems.defaultBuilder;
 
 @Mod.EventBusSubscriber(modid = LibMisc.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ModBlocks {
+	private static final AbstractBlock.IExtendedPositionPredicate<EntityType<?>> NO_SPAWN = (state, world, pos, et) -> false;
+	private static final AbstractBlock.IPositionPredicate NO_SUFFOCATION = (state, world, pos) -> false;
 
 	public static final Block cadAssembler = new BlockCADAssembler(Block.Properties.create(Material.IRON).hardnessAndResistance(5, 10).sound(SoundType.METAL).notSolid());
 	public static final Block programmer = new BlockProgrammer(Block.Properties.create(Material.IRON).hardnessAndResistance(5, 10).sound(SoundType.METAL).notSolid());
-	public static final Block conjured = new BlockConjured(Block.Properties.create(Material.GLASS).noDrops().notSolid().setLightLevel(state -> state.get(BlockConjured.LIGHT) ? 15 : 0));
+	public static final Block conjured = new BlockConjured(Block.Properties.create(Material.GLASS).noDrops().setLightLevel(state -> state.get(BlockConjured.LIGHT) ? 15 : 0).notSolid().setAllowsSpawn(NO_SPAWN).setOpaque(NO_SUFFOCATION).setSuffocates(NO_SUFFOCATION).setBlocksVision(NO_SUFFOCATION));
 	public static final Block psidustBlock = new Block(Block.Properties.create(Material.IRON).hardnessAndResistance(5, 10).sound(SoundType.METAL));
 	public static final Block psimetalBlock = new Block(Block.Properties.create(Material.IRON).hardnessAndResistance(5, 10).sound(SoundType.METAL));
 	public static final Block psigemBlock = new Block(Block.Properties.create(Material.IRON).hardnessAndResistance(5, 10).sound(SoundType.METAL));


### PR DESCRIPTION
Conjured blocks were suffocating entities and did not allow the third person camera to pass through them.
This PR fixes the above referencing Vanilla Glass and Botania's [Mana Glass](https://github.com/Vazkii/Botania/blob/7112f0291337ea66b769b1c40194557b28b56af5/src/main/java/vazkii/botania/common/block/ModBlocks.java#L247).

Also switched to using the official Sponge maven (for MixinGradle) since the creeper host one died. (Let me know if that commit is not desired and I will remove it.)

<details>
<summary>Screenshots</summary>

**After**
![Looking from behind, through the conjured blocks](https://user-images.githubusercontent.com/630920/111758225-31d01a00-88d7-11eb-8113-c1a36d6bd083.png)
![Looking from in-front, through the conjured blocks](https://user-images.githubusercontent.com/630920/111758237-34cb0a80-88d7-11eb-9424-eb8584c39eab.png)

**Before**
![Suffocating inside the conjured blocks and can't look outside](https://user-images.githubusercontent.com/630920/111758781-d7838900-88d7-11eb-8e46-9b244512a762.png)
</details>