### PR TITLE
Attempt to fix spell circle create crash

### DIFF
--- a/src/main/java/vazkii/psi/common/entity/ModEntities.java
+++ b/src/main/java/vazkii/psi/common/entity/ModEntities.java
@@ -35,7 +35,7 @@ public final class ModEntities {
 				.setTrackingRange(256)
 				.setUpdateInterval(10)
 				.setShouldReceiveVelocityUpdates(false)
-				.size(3, 0)
+				.size(3, 0.2)
 				.build("").setRegistryName(LibMisc.MOD_ID, LibEntityNames.SPELL_CIRCLE));
 		r.register(EntityType.Builder.create((EntityType.IFactory<EntitySpellGrenade>) EntitySpellGrenade::new, MISC)
 				.setTrackingRange(256)


### PR DESCRIPTION
im guessing that the create mod tried to localize the bounding boxes of something without height which caused a crash because of matrix rotation bullshit