### PR TITLE
Fix error handler param evaluation order, prevent self dependency

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/SpellCompiler.java
+++ b/src/main/java/vazkii/psi/common/spell/SpellCompiler.java
@@ -107,7 +107,7 @@ public final class SpellCompiler implements ISpellCompiler {
 			errorHandler = compiled.new CatchHandler(piece);
 			processedHandlers.add(piece);
 		}
-		
+
 		// error handler params must be evaluated before the handled piece
 		CatchHandler catchHandler = compiled.errorHandlers.get(piece);
 		if (catchHandler != null) {


### PR DESCRIPTION
Error handlers could be called before their parameters are evaluated, resulting in null values.
It was also possible to use a fallback value that depends on the target of the error handler, resulting in null values or NullPointerExceptions.

This PR fixes these problems by ensuring that params of error handlers are always evaluated before the target of the handler and by treating error handler params that depend on the target of the handler as a circular dependency.