### PR TITLE
Fix trick: spin chamber not working with loopcast

### DIFF
--- a/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
+++ b/src/main/java/vazkii/psi/common/core/handler/PlayerDataHandler.java
@@ -416,6 +416,7 @@ public class PlayerDataHandler {
 						ISpellAcceptor spellContainer = ISpellAcceptor.acceptor(bullet);
 						Spell spell = spellContainer.getSpell();
 						SpellContext context = new SpellContext().setPlayer(player).setSpell(spell).setLoopcastIndex(loopcastAmount + 1);
+						context.castFrom = loopcastHand;
 						if (context.isValid()) {
 							if (context.cspell.metadata.evaluateAgainst(cadStack)) {
 								int cost = ItemCAD.getRealCost(cadStack, bullet, context.cspell.metadata.stats.get(EnumSpellStat.COST));

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -669,4 +669,9 @@ public class ItemCAD extends Item implements ICAD {
 		return Rarity.RARE;
 	}
 
+	@Override
+	public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
+		return !oldStack.isItemEqual(newStack);
+	}
+
 }

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickRussianRoulette.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickRussianRoulette.java
@@ -20,6 +20,7 @@ import vazkii.psi.api.spell.SpellContext;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.piece.PieceTrick;
+import vazkii.psi.common.core.handler.PlayerDataHandler;
 import vazkii.psi.common.item.ItemCAD;
 
 public class PieceTrickRussianRoulette extends PieceTrick {
@@ -53,6 +54,7 @@ public class PieceTrickRussianRoulette extends PieceTrick {
 		int target = (int) ((Math.random() * sockets));
 
 		capability.setSelectedSlot(target);
+		PlayerDataHandler.get(context.caster).lastTickLoopcastStack = inHand.copy();
 
 		return null;
 	}

--- a/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSpinChamber.java
+++ b/src/main/java/vazkii/psi/common/spell/trick/PieceTrickSpinChamber.java
@@ -23,6 +23,7 @@ import vazkii.psi.api.spell.SpellParam;
 import vazkii.psi.api.spell.SpellRuntimeException;
 import vazkii.psi.api.spell.param.ParamNumber;
 import vazkii.psi.api.spell.piece.PieceTrick;
+import vazkii.psi.common.core.handler.PlayerDataHandler;
 import vazkii.psi.common.item.ItemCAD;
 
 public class PieceTrickSpinChamber extends PieceTrick {
@@ -73,6 +74,7 @@ public class PieceTrickSpinChamber extends PieceTrick {
 		int target = ((selectedSlot + offset) + sockets) % sockets;
 
 		capability.setSelectedSlot(target);
+		PlayerDataHandler.get(context.caster).lastTickLoopcastStack = inHand.copy();
 
 		return null;
 	}


### PR DESCRIPTION
Trick: spin chamber would error saying that it can only be used in a CAD when used with loopcast. This PR fixes that and prevents the CAD from playing the reequip animation when the trick changes the selected slot.