### PR TITLE
Separate saved vector count from socket count

### DIFF
--- a/src/main/java/vazkii/psi/api/cad/EnumCADStat.java
+++ b/src/main/java/vazkii/psi/api/cad/EnumCADStat.java
@@ -19,6 +19,7 @@ public enum EnumCADStat {
 	PROJECTION(EnumCADComponent.CORE),
 	BANDWIDTH(EnumCADComponent.SOCKET),
 	SOCKETS(EnumCADComponent.SOCKET),
+	SAVED_VECTORS(EnumCADComponent.SOCKET),
 	OVERFLOW(EnumCADComponent.BATTERY);
 
 	EnumCADStat(EnumCADComponent source) {

--- a/src/main/java/vazkii/psi/common/item/ItemCAD.java
+++ b/src/main/java/vazkii/psi/common/item/ItemCAD.java
@@ -521,11 +521,11 @@ public class ItemCAD extends Item implements ICAD {
 
 	@Override
 	public int getMemorySize(ItemStack stack) {
-		int sockets = getStatValue(stack, EnumCADStat.SOCKETS);
-		if (sockets == -1) {
+		int vectors = getStatValue(stack, EnumCADStat.SAVED_VECTORS);
+		if (vectors == -1) {
 			return 0xFF;
 		}
-		return sockets / 3;
+		return vectors;
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/item/component/DefaultStats.java
+++ b/src/main/java/vazkii/psi/common/item/component/DefaultStats.java
@@ -81,22 +81,27 @@ public class DefaultStats {
 		//Basic
 		ItemCADComponent.addStatToStack(ModItems.cadSocketBasic, EnumCADStat.BANDWIDTH, 5);
 		ItemCADComponent.addStatToStack(ModItems.cadSocketBasic, EnumCADStat.SOCKETS, 4);
+		ItemCADComponent.addStatToStack(ModItems.cadSocketBasic, EnumCADStat.SAVED_VECTORS, 1);
 
 		// Signaling
 		ItemCADComponent.addStatToStack(ModItems.cadSocketSignaling, EnumCADStat.BANDWIDTH, 7);
 		ItemCADComponent.addStatToStack(ModItems.cadSocketSignaling, EnumCADStat.SOCKETS, 6);
+		ItemCADComponent.addStatToStack(ModItems.cadSocketSignaling, EnumCADStat.SAVED_VECTORS, 2);
 
 		// Large
 		ItemCADComponent.addStatToStack(ModItems.cadSocketLarge, EnumCADStat.BANDWIDTH, 6);
 		ItemCADComponent.addStatToStack(ModItems.cadSocketLarge, EnumCADStat.SOCKETS, 8);
+		ItemCADComponent.addStatToStack(ModItems.cadSocketLarge, EnumCADStat.SAVED_VECTORS, 2);
 
 		// Transmissive
 		ItemCADComponent.addStatToStack(ModItems.cadSocketTransmissive, EnumCADStat.BANDWIDTH, 9);
 		ItemCADComponent.addStatToStack(ModItems.cadSocketTransmissive, EnumCADStat.SOCKETS, 10);
+		ItemCADComponent.addStatToStack(ModItems.cadSocketTransmissive, EnumCADStat.SAVED_VECTORS, 3);
 
 		// Huge
 		ItemCADComponent.addStatToStack(ModItems.cadSocketHuge, EnumCADStat.BANDWIDTH, 8);
 		ItemCADComponent.addStatToStack(ModItems.cadSocketHuge, EnumCADStat.SOCKETS, 12);
+		ItemCADComponent.addStatToStack(ModItems.cadSocketHuge, EnumCADStat.SAVED_VECTORS, 4);
 	}
 
 	public static void registerBatteryStats() {

--- a/src/main/resources/assets/psi/lang/en_us.json
+++ b/src/main/resources/assets/psi/lang/en_us.json
@@ -171,6 +171,7 @@
   "psi.cadstat.projection": "Projection",
   "psi.cadstat.bandwidth": "Bandwidth",
   "psi.cadstat.sockets": "Sockets",
+  "psi.cadstat.saved_vectors": "Saved Vectors",
   "psi.cadstat.overflow": "Overflow",
   "psi.spellstat.complexity": "Complexity",
   "psi.spellstat.complexity.desc": "Amount of actions",

--- a/src/main/resources/en_us_base.json
+++ b/src/main/resources/en_us_base.json
@@ -170,6 +170,7 @@
   "psi.cadstat.projection": "Projection",
   "psi.cadstat.bandwidth": "Bandwidth",
   "psi.cadstat.sockets": "Sockets",
+  "psi.cadstat.saved_vectors": "Saved Vectors",
   "psi.cadstat.overflow": "Overflow",
   "psi.spellstat.complexity": "Complexity",
   "psi.spellstat.complexity.desc": "Amount of actions",


### PR DESCRIPTION
The number of saved vectors available should be independent from the number of sockets available. This would allow addons to add sockets with independent saved vector and socket count. For sockets added by Psi the saved vector count is the same as before with saved vector count added to their tooltip.