### PR TITLE
Give addons more control over socket selector GUI

### DIFF
--- a/src/main/java/vazkii/psi/api/cad/ISocketable.java
+++ b/src/main/java/vazkii/psi/api/cad/ISocketable.java
@@ -9,18 +9,40 @@
 package vazkii.psi.api.cad;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 
 import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.spell.ISpellAcceptor;
+import vazkii.psi.common.lib.LibResources;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This capability defines items that can have Spell Bullets inserted into them.
  */
 public interface ISocketable {
 
-	int MAX_SLOTS = 12;
+	List<ResourceLocation> signs = Arrays.asList(
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 0)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 1)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 2)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 3)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 4)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 5)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 6)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 7)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 8)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 9)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 10)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 11)),
+			new ResourceLocation(String.format(LibResources.GUI_SIGN, 12))
+	);
+
+	int MAX_ASSEMBLER_SLOTS = 12;
 
 	static ITextComponent getSocketedItemName(ItemStack stack, String fallbackKey) {
 		if (stack.isEmpty() || !isSocketable(stack)) {
@@ -46,8 +68,18 @@ public interface ISocketable {
 
 	boolean isSocketSlotAvailable(int slot);
 
-	default boolean showSlotInRadialMenu(int slot) {
-		return isSocketSlotAvailable(slot);
+	default List<Integer> getRadialMenuSlots() {
+		List<Integer> list = new ArrayList<>();
+		for (int i = 0; i < MAX_ASSEMBLER_SLOTS; i++) {
+			if (isSocketSlotAvailable(i)) {
+				list.add(i);
+			}
+		}
+		return list;
+	}
+
+	default List<ResourceLocation> getRadialMenuIcons() {
+		return signs;
 	}
 
 	ItemStack getBulletInSocket(int slot);

--- a/src/main/java/vazkii/psi/client/gui/GuiSocketSelect.java
+++ b/src/main/java/vazkii/psi/client/gui/GuiSocketSelect.java
@@ -36,7 +36,6 @@ import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.client.core.handler.KeybindHandler;
 import vazkii.psi.common.Psi;
 import vazkii.psi.common.core.handler.PlayerDataHandler;
-import vazkii.psi.common.lib.LibResources;
 import vazkii.psi.common.network.MessageRegister;
 import vazkii.psi.common.network.message.MessageChangeControllerSlot;
 import vazkii.psi.common.network.message.MessageChangeSocketableSlot;
@@ -45,22 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GuiSocketSelect extends Screen {
-
-	private static final ResourceLocation[] signs = new ResourceLocation[] {
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 0)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 1)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 2)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 3)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 4)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 5)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 6)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 7)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 8)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 9)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 10)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 11)),
-			new ResourceLocation(String.format(LibResources.GUI_SIGN, 12))
-	};
 
 	int timeIn = 0;
 	int slotSelected = -1;
@@ -73,6 +56,7 @@ public class GuiSocketSelect extends Screen {
 	ItemStack socketableStack;
 	ISocketable socketable;
 	List<Integer> slots;
+	List<ResourceLocation> signs;
 	final Minecraft mc;
 
 	public GuiSocketSelect(ItemStack stack) {
@@ -98,19 +82,15 @@ public class GuiSocketSelect extends Screen {
 	}
 
 	public void setSocketable(ItemStack stack) {
-		slots = new ArrayList<>();
 		if (stack.isEmpty()) {
+			slots = new ArrayList<>();
 			return;
 		}
 
 		socketableStack = stack;
 		socketable = ISocketable.socketable(stack);
-
-		for (int i = 0; i < ISocketable.MAX_SLOTS; i++) {
-			if (socketable.showSlotInRadialMenu(i)) {
-				slots.add(i);
-			}
-		}
+		slots = socketable.getRadialMenuSlots();
+		signs = socketable.getRadialMenuIcons();
 	}
 
 	@Override
@@ -243,7 +223,7 @@ public class GuiSocketSelect extends Screen {
 				xdp = (int) ((xp - x) * mod + x);
 				ydp = (int) ((yp - y) * mod + y);
 
-				mc.textureManager.bindTexture(signs[seg]);
+				mc.textureManager.bindTexture(signs.get(seg));
 				blit(ms, xdp - 8, ydp - 8, 0, 0, 16, 16, 16, 16);
 			}
 		}

--- a/src/main/java/vazkii/psi/common/core/handler/capability/SocketWheel.java
+++ b/src/main/java/vazkii/psi/common/core/handler/capability/SocketWheel.java
@@ -15,6 +15,9 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import vazkii.psi.api.cad.ISocketable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SocketWheel implements ISocketable, INBTSerializable<CompoundNBT> {
 
 	private final int size;
@@ -24,7 +27,7 @@ public class SocketWheel implements ISocketable, INBTSerializable<CompoundNBT> {
 	private int selectedSlot = 0;
 
 	public SocketWheel() {
-		this(ISocketable.MAX_SLOTS);
+		this(ISocketable.MAX_ASSEMBLER_SLOTS);
 	}
 
 	public SocketWheel(int size) {
@@ -35,6 +38,17 @@ public class SocketWheel implements ISocketable, INBTSerializable<CompoundNBT> {
 	@Override
 	public boolean isSocketSlotAvailable(int slot) {
 		return slot < size;
+	}
+
+	@Override
+	public List<Integer> getRadialMenuSlots() {
+		List<Integer> list = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			if (isSocketSlotAvailable(i)) {
+				list.add(i);
+			}
+		}
+		return list;
 	}
 
 	@Override

--- a/src/main/java/vazkii/psi/common/item/tool/ToolSocketable.java
+++ b/src/main/java/vazkii/psi/common/item/tool/ToolSocketable.java
@@ -27,6 +27,9 @@ import vazkii.psi.api.spell.Spell;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ToolSocketable implements ICapabilityProvider, ISocketable, IPsiBarDisplay, ISpellAcceptor {
 	protected final ItemStack tool;
 	protected final int slots;
@@ -35,7 +38,7 @@ public class ToolSocketable implements ICapabilityProvider, ISocketable, IPsiBar
 
 	public ToolSocketable(ItemStack tool, int slots) {
 		this.tool = tool;
-		this.slots = MathHelper.clamp(slots, 1, MAX_SLOTS - 1);
+		this.slots = MathHelper.clamp(slots, 1, MAX_ASSEMBLER_SLOTS - 1);
 		this.capOptional = LazyOptional.of(() -> this);
 	}
 
@@ -56,8 +59,12 @@ public class ToolSocketable implements ICapabilityProvider, ISocketable, IPsiBar
 	}
 
 	@Override
-	public boolean showSlotInRadialMenu(int slot) {
-		return isSocketSlotAvailable(slot - 1);
+	public List<Integer> getRadialMenuSlots() {
+		List<Integer> list = new ArrayList<>();
+		for (int i = 0; i <= slots; i++) {
+			list.add(i);
+		}
+		return list;
 	}
 
 	@Override


### PR DESCRIPTION
Allows addons to use more than 12 slots and display their custom icons in the socket selector GUI.