### PR TITLE
Add shortcut to switch Number Constant back to positive

### DIFF
--- a/src/main/java/vazkii/psi/common/spell/constant/PieceConstantNumber.java
+++ b/src/main/java/vazkii/psi/common/spell/constant/PieceConstantNumber.java
@@ -75,15 +75,17 @@ public class PieceConstantNumber extends SpellPiece {
 
 		String oldStr = valueStr;
 		String newStr = valueStr;
-		if (newStr.equals("0") || newStr.equals("-0")) {
-			if (character == '-') {
-				newStr = "-0";
-			} else if (character != '.') {
-				newStr = newStr.replace("0", "");
-			}
+		if ((newStr.equals("0") || newStr.equals("-0")) && "+-.".indexOf(character) < 0) {
+			newStr = newStr.replace("0", "");
 		}
 
-		if (character != '-') {
+		if (character == '+') {
+			newStr = newStr.replace("-", "");
+		} else if (character == '-') {
+			if (!newStr.startsWith("-")) {
+				newStr = "-" + newStr;
+			}
+		} else {
 			newStr += character;
 		}
 


### PR DESCRIPTION
Number Constants had to be re-added when switching their signs. This PR allows the sign of the constant to be switched to positive with '+' and to negative with '-' without having to delete its value.