### PR TITLE
Draw overlapping params properly, arrow type API

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellParam.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellParam.java
@@ -135,6 +135,13 @@ public abstract class SpellParam<T> {
 	}
 
 	/**
+	 * Gets the {@link ArrowType} that should be drawn for this parameter.
+	 */
+	public ArrowType getArrowType() {
+		return arrowType;
+	}
+
+	/**
 	 * Helper Enum for the various sides a parameter can take.
 	 */
 	public enum Side {

--- a/src/main/java/vazkii/psi/api/spell/SpellParam.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellParam.java
@@ -80,11 +80,17 @@ public abstract class SpellParam<T> {
 	public final String name;
 	public final int color;
 	public final boolean canDisable;
+	public final ArrowType arrowType;
 
 	public SpellParam(String name, int color, boolean canDisable) {
+		this(name, color, canDisable, ArrowType.IN);
+	}
+
+	public SpellParam(String name, int color, boolean canDisable, ArrowType arrowType) {
 		this.name = name;
 		this.color = color;
 		this.canDisable = canDisable;
+		this.arrowType = arrowType;
 	}
 
 	/**
@@ -132,19 +138,23 @@ public abstract class SpellParam<T> {
 	 * Helper Enum for the various sides a parameter can take.
 	 */
 	public enum Side {
-		OFF(0, 0, 238, 0),
-		TOP(0, -1, 222, 8),
-		BOTTOM(0, 1, 230, 8),
-		LEFT(-1, 0, 230, 0),
-		RIGHT(1, 0, 222, 0);
+		OFF(0, 0, 0, 0, 0, 0, 238, 0),
+		TOP(0, -1, 4, -9, -4, -9, 222, 8),
+		BOTTOM(0, 1, 4, 9, -4, 9, 230, 8),
+		LEFT(-1, 0, -9, 4, -9, -4, 230, 0),
+		RIGHT(1, 0, 9, 4, 9, -4, 222, 0);
 
 		public static final Side[] DIRECTIONS = new Side[] { TOP, BOTTOM, LEFT, RIGHT };
 
-		public final int offx, offy, u, v;
+		public final int offx, offy, minx, miny, maxx, maxy, u, v;
 
-		Side(int offx, int offy, int u, int v) {
+		Side(int offx, int offy, int minx, int miny, int maxx, int maxy, int u, int v) {
 			this.offx = offx;
 			this.offy = offy;
+			this.minx = minx;
+			this.miny = miny;
+			this.maxx = maxx;
+			this.maxy = maxy;
 			this.u = u;
 			this.v = v;
 		}
@@ -191,6 +201,15 @@ public abstract class SpellParam<T> {
 				return OFF;
 			}
 		}
+	}
+
+	/**
+	 * Helper enum for the various arrow types that can be drawn for a parameter.
+	 */
+	public enum ArrowType {
+		NONE,
+		OUT,
+		IN
 	}
 
 	/**

--- a/src/main/java/vazkii/psi/api/spell/SpellPiece.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellPiece.java
@@ -36,6 +36,7 @@ import vazkii.psi.api.ClientPsiAPI;
 import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.api.internal.TooltipHelper;
+import vazkii.psi.api.spell.SpellParam.ArrowType;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -353,33 +354,72 @@ public abstract class SpellPiece {
 	public void drawParams(MatrixStack ms, IRenderTypeBuffer buffers, int light) {
 		IVertexBuilder buffer = buffers.getBuffer(PsiAPI.internalHandler.getProgrammerLayer());
 		for (SpellParam<?> param : paramSides.keySet()) {
-			SpellParam.Side side = paramSides.get(param);
-			if (side.isEnabled()) {
-				int minX = 4;
-				int minY = 4;
-				minX += side.offx * 9;
-				minY += side.offy * 9;
+			drawParam(ms, buffer, light, param);
+		}
+	}
 
-				int maxX = minX + 8;
-				int maxY = minY + 8;
+	@OnlyIn(Dist.CLIENT)
+	public void drawParam(MatrixStack ms, IVertexBuilder buffer, int light, SpellParam<?> param) {
+		SpellParam.Side side = paramSides.get(param);
+		if (!side.isEnabled() || param.arrowType == ArrowType.NONE) {
+			return;
+		}
 
-				float wh = 8F;
-				float minU = side.u / 256F;
-				float minV = side.v / 256F;
-				float maxU = (side.u + wh) / 256F;
-				float maxV = (side.v + wh) / 256F;
-				int r = PsiRenderHelper.r(param.color);
-				int g = PsiRenderHelper.g(param.color);
-				int b = PsiRenderHelper.b(param.color);
-				int a = 255;
-				Matrix4f mat = ms.getLast().getMatrix();
-
-				buffer.pos(mat, minX, maxY, 0).color(r, g, b, a).tex(minU, maxV).lightmap(light).endVertex();
-				buffer.pos(mat, maxX, maxY, 0).color(r, g, b, a).tex(maxU, maxV).lightmap(light).endVertex();
-				buffer.pos(mat, maxX, minY, 0).color(r, g, b, a).tex(maxU, minV).lightmap(light).endVertex();
-				buffer.pos(mat, minX, minY, 0).color(r, g, b, a).tex(minU, minV).lightmap(light).endVertex();
+		int index = 0, count = 0;
+		for (SpellParam<?> p : paramSides.keySet()) {
+			if (p == param) {
+				index = count;
+			}
+			if (p.arrowType != ArrowType.NONE && paramSides.get(p) == side) {
+				count++;
 			}
 		}
+		SpellPiece neighbour = spell.grid.getPieceAtSideSafely(x, y, side);
+		if (neighbour != null) {
+			int nbcount = 0;
+			for (SpellParam<?> p : neighbour.paramSides.keySet()) {
+				if (p.arrowType != ArrowType.NONE && neighbour.paramSides.get(p) == side.getOpposite()) {
+					nbcount++;
+				}
+			}
+			if (side.asInt() > side.getOpposite().asInt()) {
+				index += nbcount;
+			}
+			count += nbcount;
+		}
+
+		float minX = 4;
+		float minY = 4;
+		if (count == 1) {
+			minX += (side.minx + side.maxx) / 2;
+			minY += (side.miny + side.maxy) / 2;
+		} else {
+			float percent = (float) index / (count - 1);
+			minX += side.minx * percent + side.maxx * (1 - percent);
+			minY += side.miny * percent + side.maxy * (1 - percent);
+		}
+
+		float maxX = minX + 8;
+		float maxY = minY + 8;
+
+		if (param.arrowType == ArrowType.OUT) {
+			side = side.getOpposite();
+		}
+		float wh = 8F;
+		float minU = side.u / 256F;
+		float minV = side.v / 256F;
+		float maxU = (side.u + wh) / 256F;
+		float maxV = (side.v + wh) / 256F;
+		int r = PsiRenderHelper.r(param.color);
+		int g = PsiRenderHelper.g(param.color);
+		int b = PsiRenderHelper.b(param.color);
+		int a = 255;
+		Matrix4f mat = ms.getLast().getMatrix();
+
+		buffer.pos(mat, minX, maxY, 0).color(r, g, b, a).tex(minU, maxV).lightmap(light).endVertex();
+		buffer.pos(mat, maxX, maxY, 0).color(r, g, b, a).tex(maxU, maxV).lightmap(light).endVertex();
+		buffer.pos(mat, maxX, minY, 0).color(r, g, b, a).tex(maxU, minV).lightmap(light).endVertex();
+		buffer.pos(mat, minX, minY, 0).color(r, g, b, a).tex(minU, minV).lightmap(light).endVertex();
 	}
 
 	/**

--- a/src/main/java/vazkii/psi/api/spell/SpellPiece.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellPiece.java
@@ -361,7 +361,7 @@ public abstract class SpellPiece {
 	@OnlyIn(Dist.CLIENT)
 	public void drawParam(MatrixStack ms, IVertexBuilder buffer, int light, SpellParam<?> param) {
 		SpellParam.Side side = paramSides.get(param);
-		if (!side.isEnabled() || param.arrowType == ArrowType.NONE) {
+		if (!side.isEnabled() || param.getArrowType() == ArrowType.NONE) {
 			return;
 		}
 
@@ -370,7 +370,7 @@ public abstract class SpellPiece {
 			if (p == param) {
 				index = count;
 			}
-			if (p.arrowType != ArrowType.NONE && paramSides.get(p) == side) {
+			if (p.getArrowType() != ArrowType.NONE && paramSides.get(p) == side) {
 				count++;
 			}
 		}
@@ -378,7 +378,7 @@ public abstract class SpellPiece {
 		if (neighbour != null) {
 			int nbcount = 0;
 			for (SpellParam<?> p : neighbour.paramSides.keySet()) {
-				if (p.arrowType != ArrowType.NONE && neighbour.paramSides.get(p) == side.getOpposite()) {
+				if (p.getArrowType() != ArrowType.NONE && neighbour.paramSides.get(p) == side.getOpposite()) {
 					nbcount++;
 				}
 			}
@@ -402,7 +402,7 @@ public abstract class SpellPiece {
 		float maxX = minX + 8;
 		float maxY = minY + 8;
 
-		if (param.arrowType == ArrowType.OUT) {
+		if (param.getArrowType() == ArrowType.OUT) {
 			side = side.getOpposite();
 		}
 		float wh = 8F;

--- a/src/main/java/vazkii/psi/api/spell/param/ParamAny.java
+++ b/src/main/java/vazkii/psi/api/spell/param/ParamAny.java
@@ -16,6 +16,10 @@ public class ParamAny extends SpellParam<SpellParam.Any> {
 		super(name, color, canDisable);
 	}
 
+	public ParamAny(String name, int color, boolean canDisable, ArrowType arrowType) {
+		super(name, color, canDisable, arrowType);
+	}
+
 	@Override
 	public Class<Any> getRequiredType() {
 		return Any.class;

--- a/src/main/java/vazkii/psi/common/spell/other/PieceCrossConnector.java
+++ b/src/main/java/vazkii/psi/common/spell/other/PieceCrossConnector.java
@@ -21,7 +21,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import vazkii.psi.api.ClientPsiAPI;
-import vazkii.psi.api.PsiAPI;
 import vazkii.psi.api.internal.PsiRenderHelper;
 import vazkii.psi.api.spell.EnumPieceType;
 import vazkii.psi.api.spell.EnumSpellStat;
@@ -31,6 +30,7 @@ import vazkii.psi.api.spell.SpellCompilationException;
 import vazkii.psi.api.spell.SpellContext;
 import vazkii.psi.api.spell.SpellMetadata;
 import vazkii.psi.api.spell.SpellParam;
+import vazkii.psi.api.spell.SpellParam.ArrowType;
 import vazkii.psi.api.spell.SpellPiece;
 import vazkii.psi.api.spell.param.ParamAny;
 import vazkii.psi.common.lib.LibResources;
@@ -52,9 +52,9 @@ public class PieceCrossConnector extends SpellPiece implements IGenericRedirecto
 	@Override
 	public void initParams() {
 		addParam(in1 = new ParamAny(SpellParam.CONNECTOR_NAME_FROM1, LINE_ONE, false));
-		addParam(out1 = new ParamAny(SpellParam.CONNECTOR_NAME_TO1, LINE_ONE, false));
+		addParam(out1 = new ParamAny(SpellParam.CONNECTOR_NAME_TO1, LINE_ONE, false, ArrowType.NONE));
 		addParam(in2 = new ParamAny(SpellParam.CONNECTOR_NAME_FROM2, LINE_TWO, false));
-		addParam(out2 = new ParamAny(SpellParam.CONNECTOR_NAME_TO2, LINE_TWO, false));
+		addParam(out2 = new ParamAny(SpellParam.CONNECTOR_NAME_TO2, LINE_TWO, false, ArrowType.NONE));
 	}
 
 	@Override
@@ -123,43 +123,6 @@ public class PieceCrossConnector extends SpellPiece implements IGenericRedirecto
 			buffer.tex(maxU, minV).lightmap(light).endVertex();
 			buffer.pos(mat, 0, 0, 0).color(r, g, b, 1F);
 			buffer.tex(minU, minV).lightmap(light).endVertex();
-		}
-	}
-
-	@Override
-	@OnlyIn(Dist.CLIENT)
-	public void drawParams(MatrixStack ms, IRenderTypeBuffer buffers, int light) {
-		drawParam(ms, buffers, light, in1);
-		drawParam(ms, buffers, light, in2);
-	}
-
-	public void drawParam(MatrixStack ms, IRenderTypeBuffer buffers, int light, SpellParam<?> param) {
-		IVertexBuilder buffer = buffers.getBuffer(PsiAPI.internalHandler.getProgrammerLayer());
-		SpellParam.Side side = paramSides.get(param);
-		if (side.isEnabled()) {
-			int minX = 4;
-			int minY = 4;
-			minX += side.offx * 9;
-			minY += side.offy * 9;
-
-			int maxX = minX + 8;
-			int maxY = minY + 8;
-
-			float wh = 8F;
-			float minU = side.u / 256F;
-			float minV = side.v / 256F;
-			float maxU = (side.u + wh) / 256F;
-			float maxV = (side.v + wh) / 256F;
-			int r = PsiRenderHelper.r(param.color);
-			int g = PsiRenderHelper.g(param.color);
-			int b = PsiRenderHelper.b(param.color);
-			int a = 255;
-			Matrix4f mat = ms.getLast().getMatrix();
-
-			buffer.pos(mat, minX, maxY, 0).color(r, g, b, a).tex(minU, maxV).lightmap(light).endVertex();
-			buffer.pos(mat, maxX, maxY, 0).color(r, g, b, a).tex(maxU, maxV).lightmap(light).endVertex();
-			buffer.pos(mat, maxX, minY, 0).color(r, g, b, a).tex(maxU, minV).lightmap(light).endVertex();
-			buffer.pos(mat, minX, minY, 0).color(r, g, b, a).tex(minU, minV).lightmap(light).endVertex();
 		}
 	}
 


### PR DESCRIPTION
Makes it easier to see which parameter is on the same side as another one and where, also useful for rendering something like my circle connector properly.
Arrow type API removes the need to reimplement parameter drawing for every piece which doesn't draw an arrow for one of its parameters, like cross connector.