### PR TITLE
Add API for checking piece input sides

### DIFF
--- a/src/main/java/vazkii/psi/api/spell/SpellPiece.java
+++ b/src/main/java/vazkii/psi/api/spell/SpellPiece.java
@@ -143,6 +143,14 @@ public abstract class SpellPiece {
 	}
 
 	/**
+	 * Checks whether the piece accepts an input on the given side.
+	 * Used by connectors to display output lines.
+	 */
+	public boolean isInputSide(SpellParam.Side side) {
+		return paramSides.containsValue(side);
+	}
+
+	/**
 	 * Defaulted version of getParamValue
 	 * Should be used for optional params
 	 */

--- a/src/main/java/vazkii/psi/common/spell/other/PieceConnector.java
+++ b/src/main/java/vazkii/psi/common/spell/other/PieceConnector.java
@@ -61,14 +61,8 @@ public class PieceConnector extends SpellPiece implements IRedirector {
 			for (SpellParam.Side side : SpellParam.Side.class.getEnumConstants()) {
 				if (side.isEnabled()) {
 					SpellPiece piece = spell.grid.getPieceAtSideSafely(x, y, side);
-					if (piece != null) {
-						for (SpellParam<?> param : piece.paramSides.keySet()) {
-							SpellParam.Side paramSide = piece.paramSides.get(param);
-							if (paramSide.getOpposite() == side) {
-								drawSide(ms, buffers, light, side);
-								break;
-							}
-						}
+					if (piece != null && piece.isInputSide(side.getOpposite())) {
+						drawSide(ms, buffers, light, side);
 					}
 				}
 			}

--- a/src/main/java/vazkii/psi/common/spell/other/PieceCrossConnector.java
+++ b/src/main/java/vazkii/psi/common/spell/other/PieceCrossConnector.java
@@ -58,6 +58,11 @@ public class PieceCrossConnector extends SpellPiece implements IGenericRedirecto
 	}
 
 	@Override
+	public boolean isInputSide(SpellParam.Side side) {
+		return paramSides.get(in1) == side || paramSides.get(in2) == side;
+	}
+
+	@Override
 	public String getSortingName() {
 		return "00000000000";
 	}


### PR DESCRIPTION
It would allow displaying connectors properly with pieces that have "output parameters" like the cross connector or have connections that don't have a parameter associated like my clockwise connector.